### PR TITLE
Navigation: Change behavior of the switch between Projects and Models

### DIFF
--- a/src/components/navigation/ModelNavList.vue
+++ b/src/components/navigation/ModelNavList.vue
@@ -7,24 +7,31 @@
     <v-form>
       <v-container class="py-0">
         <v-text-field
+          :prepend-icon="
+            implementedModels.length === state.models.length
+              ? 'mdi-filter-outline'
+              : 'mdi-filter-off-outline'
+          "
+          @click:append="clearSearch"
+          @click:prepend="filterModels"
           clearable
           hide-details
           label="Search model"
           prepend-inner-icon="mdi-magnify"
+          v-model="state.searchTerm"
         />
       </v-container>
     </v-form>
 
-    <v-list dense>
+    <v-list dense :style="{ fontSize: '14px' }">
       <v-list-item
-        :key="model.id"
-        :to="'/model/' + model.id"
+        :class="{ 'font-weight-bold': implementedModels.includes(model) }"
+        :key="model"
+        :to="'/model/' + model"
         v-for="model in state.models"
-      >
-        <v-list-item-content>
-          <v-list-item-title v-text="model.label" />
-        </v-list-item-content>
-      </v-list-item>
+        v-show="state.searchTerm ? model.includes(state.searchTerm) : true"
+        v-text="model"
+      />
     </v-list>
   </div>
 </template>
@@ -32,16 +39,44 @@
 <script lang="ts">
 import Vue from 'vue';
 import { reactive } from '@vue/composition-api';
+import axios from 'axios';
 
 import core from '@/core';
 
 export default Vue.extend({
   name: 'Models',
   setup() {
+    const implementedModels = core.app.models.map(model => model.id);
+
     const state = reactive({
-      models: core.app.models,
+      models: implementedModels,
+      searchTerm: '',
     });
-    return { state };
+
+    /**
+     * Clear search term.
+     */
+    const clearSearch = () => {
+      state.searchTerm = '';
+    };
+
+    /**
+     * Show implemented or all models
+     */
+    const filterModels = () => {
+      if (state.models.length !== implementedModels.length) {
+        // Use implemented models
+        state.models = implementedModels;
+      } else {
+        // Fetch models from NEST Server API.
+        const url = `${core.app.nestServer.url}/api/Models`;
+        axios.get(url).then(resp => {
+          state.models = resp.data;
+        });
+      }
+    };
+
+    return { clearSearch, filterModels, implementedModels, state };
   },
 });
 </script>

--- a/src/components/navigation/Navigation.vue
+++ b/src/components/navigation/Navigation.vue
@@ -209,7 +209,14 @@ export default {
      */
     function redirect(targetRouteId: string, router: VueRouter) {
       if (targetRouteId === 'project') {
-        if (recentProjectId == undefined || recentProjectId.length <= 0) {
+        // check if project ID is undefined or project does not exist anymore
+        if (
+          recentProjectId == undefined ||
+          recentProjectId.length <= 0 ||
+          state.app.view.filteredProjects.filter(
+            project => project.id == recentProjectId
+          ).length <= 0
+        ) {
           recentProjectId = state.app.view.filteredProjects[0].id;
         }
         router.push({

--- a/src/components/navigation/Navigation.vue
+++ b/src/components/navigation/Navigation.vue
@@ -209,7 +209,7 @@ export default {
      */
     function redirect(targetRouteId: string, router: VueRouter) {
       if (targetRouteId === 'project') {
-        if (recentProjectId == '') {
+        if (recentProjectId == undefined || recentProjectId.length <= 0) {
           recentProjectId = state.app.view.filteredProjects[0].id;
         }
         router.push({
@@ -217,7 +217,7 @@ export default {
           params: { id: recentProjectId },
         });
       } else {
-        if (recentModelId == undefined) {
+        if (recentModelId == undefined || recentModelId.length <= 0) {
           recentModelId = 'ac_generator';
         }
         router.push({ name: 'ModelId', params: { id: recentModelId } });


### PR DESCRIPTION
This PR simplifies the switching between the 'Model' and 'Project' view: It stores the least recently viewed model/project and selects it without any further interaction.
Before:
![NEST_Desktop_before](https://user-images.githubusercontent.com/53972736/122417242-a4f63480-cf89-11eb-8915-ba80591c667c.gif)
After:
![NEST_Desktop_after](https://user-images.githubusercontent.com/53972736/122417344-b2132380-cf89-11eb-87c1-408ea9766c98.gif)
