### PR TITLE
No need to format parameter values to float.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - '8000:8000'
   nest-server:
-    image: nestsim/nest:3.0
+    image: nestsim/nest:latest
     command: 'nest-server start -o'
     container_name: 'nest-server'
     environment:

--- a/src/assets/config/Connection.json
+++ b/src/assets/config/Connection.json
@@ -54,7 +54,6 @@
         {
           "id": "indegree",
           "input": "valueSlider",
-          "format": "integer",
           "label": "indegree",
           "max": 100,
           "min": 1,
@@ -73,7 +72,6 @@
           "visible": false
         },
         {
-          "format": "boolean",
           "id": "allow_autapses",
           "input": "checkbox",
           "label": "allow autapses",
@@ -81,7 +79,6 @@
           "visible": false
         },
         {
-          "format": "boolean",
           "id": "allow_multapses",
           "input": "checkbox",
           "label": "allow multapses",
@@ -97,7 +94,6 @@
         {
           "id": "outdegree",
           "input": "valueSlider",
-          "format": "integer",
           "label": "outdegree",
           "max": 100,
           "min": 1,
@@ -116,7 +112,6 @@
           "visible": false
         },
         {
-          "format": "boolean",
           "id": "allow_autapses",
           "input": "checkbox",
           "label": "allow autapses",
@@ -124,7 +119,6 @@
           "visible": false
         },
         {
-          "format": "boolean",
           "id": "allow_multapses",
           "input": "checkbox",
           "label": "allow multapses",
@@ -138,7 +132,6 @@
       "label": "fixed total number",
       "params": [
         {
-          "format": "integer",
           "id": "N",
           "input": "valueSlider",
           "label": "N",
@@ -149,7 +142,6 @@
           "visible": true
         },
         {
-          "format": "boolean",
           "id": "allow_autapses",
           "input": "checkbox",
           "label": "allow autapses",
@@ -157,7 +149,6 @@
           "visible": false
         },
         {
-          "format": "boolean",
           "id": "allow_multapses",
           "input": "checkbox",
           "label": "allow multapses",
@@ -193,7 +184,6 @@
           "visible": false
         },
         {
-          "format": "boolean",
           "id": "use_on_source",
           "input": "checkbox",
           "label": "use on source",
@@ -217,7 +207,6 @@
           "visible": true
         },
         {
-          "format": "boolean",
           "id": "allow_autapses",
           "input": "checkbox",
           "label": "allow autapses",
@@ -226,7 +215,6 @@
           "visible": true
         },
         {
-          "format": "boolean",
           "id": "make_symmetric",
           "input": "checkbox",
           "label": "make symmetric",
@@ -235,7 +223,6 @@
           "visible": true
         },
         {
-          "format": "boolean",
           "id": "use_on_source",
           "input": "checkbox",
           "label": "use on source",

--- a/src/assets/models/spike_generator.json
+++ b/src/assets/models/spike_generator.json
@@ -5,14 +5,12 @@
   "label": "spike generator",
   "params": [
     {
-      "format": "array",
       "id": "spike_times",
       "label": "spike times",
       "unit": "ms",
       "input": "arrayInput"
     },
     {
-      "format": "array",
       "id": "spike_weights",
       "label": "weights of spike",
       "unit": "pA",

--- a/src/assets/models/step_current_generator.json
+++ b/src/assets/models/step_current_generator.json
@@ -5,14 +5,12 @@
   "recordables": ["I"],
   "params": [
     {
-      "format": "array",
       "id": "amplitude_times",
       "label": "times at which current changes",
       "unit": "ms",
       "input": "arrayInput"
     },
     {
-      "format": "array",
       "id": "amplitude_values",
       "label": "amplitudes of step current current",
       "unit": "pA",

--- a/src/components/parameter/ParameterEdit.vue
+++ b/src/components/parameter/ParameterEdit.vue
@@ -311,6 +311,8 @@ export default Vue.extend({
     };
 
     const generateValues = () => {
+      state.valueGenerator.sort =
+        state.param.id.includes('time') || state.param.id.includes('Time');
       state.value = state.valueGenerator.generate();
       paramChange();
     };

--- a/src/core/code.ts
+++ b/src/core/code.ts
@@ -16,26 +16,14 @@ export class Code {
   }
 
   /**
-   * Format float value or array.
+   * Format value or array to string.
    */
-  format(value: any): any {
-    if (Number.isInteger(value)) {
-      return this.floatToFixed(value);
-    } else if (Array.isArray(value)) {
+  format(value: any): string {
+    if (Array.isArray(value)) {
       return `[${String(value.map((v: any) => this.format(v)))}]`;
     } else {
-      return value;
+      return JSON.stringify(value);
     }
   }
 
-  /**
-   * Generate fixed float value with correct amount of decimals.
-   */
-  floatToFixed(value: number): string {
-    const valString: string = JSON.stringify(value);
-    const valList: string[] = valString.split('.');
-    return value.toFixed(
-      valList.length === 2 ? Math.min(valList[1].length, 20) : 1
-    );
-  }
 }

--- a/src/core/code.ts
+++ b/src/core/code.ts
@@ -14,16 +14,4 @@ export class Code {
   end(): string {
     return '\n';
   }
-
-  /**
-   * Format value or array to string.
-   */
-  format(value: any): string {
-    if (Array.isArray(value)) {
-      return `[${String(value.map((v: any) => this.format(v)))}]`;
-    } else {
-      return JSON.stringify(value);
-    }
-  }
-
 }

--- a/src/core/connection/connectionCode.ts
+++ b/src/core/connection/connectionCode.ts
@@ -23,15 +23,18 @@ export class ConnectionCode extends Code {
   /**
    * Write script of connection specifications.
    */
-  connSpec(): string {
-    const connSpecList: string[] = [`"rule": "${this._connection.rule}"`];
+  specs(): string {
+    const specs: string[] = [`"rule": "${this._connection.rule}"`];
     this._connection.filteredParams.forEach((param: Parameter) =>
-      connSpecList.push(`"${param.id}": ${param.toCode()}`)
+      specs.push(`"${param.id}": ${param.toCode()}`)
     );
 
-    let script = ', conn_spec={' + this._();
-    script += connSpecList.join(',' + this._());
-    script += this.end() + '}';
+    let script = '';
+    if (specs.length > 1 && this._connection.rule !== 'all_to_all') {
+      script += ', conn_spec={' + this._();
+      script += specs.join(',' + this._());
+      script += this.end() + '}';
+    }
     return script;
   }
 
@@ -48,8 +51,8 @@ export class ConnectionCode extends Code {
 
     let script = '';
     script += `nest.Connect(${this.sourceLabel}, ${this.targetLabel}`;
-    script += this.connSpec();
-    script += this._connection.synapse.code.synSpec();
+    script += this.specs();
+    script += this._connection.synapse.code.specs();
     script += ')';
     return script + '\n';
   }

--- a/src/core/connection/synapseCode.ts
+++ b/src/core/connection/synapseCode.ts
@@ -14,20 +14,20 @@ export class SynapseCode extends Code {
   /**
    * Write script of synapse specifications.
    */
-  synSpec(): string {
-    const synSpecList: string[] = [];
+  specs(): string {
+    const specs: string[] = [];
     if (this._synapse.modelId !== 'static_synapse') {
-      synSpecList.push(`"model": "${this._synapse.modelId}"`);
+      specs.push(`"model": "${this._synapse.modelId}"`);
     }
 
     this._synapse.filteredParams.forEach((param: ModelParameter) =>
-      synSpecList.push(`"${param.id}": ${param.toCode()}`)
+      specs.push(`"${param.id}": ${param.toCode()}`)
     );
 
     let script = '';
-    if (synSpecList.length > 0) {
+    if (specs.length > 0) {
       script += ', syn_spec={' + this._();
-      script += synSpecList.join(',' + this._());
+      script += specs.join(',' + this._());
       script += this.end() + '}';
     }
     return script;

--- a/src/core/model/modelCode.ts
+++ b/src/core/model/modelCode.ts
@@ -34,16 +34,11 @@ export class ModelCode extends Code {
       .filter((param: ModelParameter) => param.visible)
       .map((param: ModelParameter) => {
         if (param.id === 'record_from') {
-          const recordFrom: string[] = param.value.map(
-            (val: string) => `"${val}"`
-          );
           paramsList.push(
-            this._() + `"${param.id}": [${recordFrom.join(',')}]`
+            this._() + `"${param.id}": [${param.value.join(',')}]`
           );
         } else {
-          paramsList.push(
-            this._() + `"${param.id}": ${this.format(param.value)}`
-          );
+          paramsList.push(this._() + `"${param.id}": ${param.value}`);
         }
       });
     if (paramsList.length > 0) {

--- a/src/core/network/networkCode.ts
+++ b/src/core/network/networkCode.ts
@@ -51,11 +51,12 @@ export class NetworkCode extends Code {
    */
   getActivities(): string {
     let script = '[';
-    script += this._(2);
     const activities: string[] = this._network.recorders.map(
       (node: Node) => `getActivity(${node.view.label})`
     );
-    script += activities.join(',' + this._(2));
+    if (activities.length > 0) {
+      script += this._(2) + activities.join(',' + this._(2));
+    }
     script += this._() + ']';
     return script;
   }

--- a/src/core/node/nodeCode.ts
+++ b/src/core/node/nodeCode.ts
@@ -34,11 +34,14 @@ export class NodeCode extends Code {
     }
     const params: string = this.nodeParams();
     if (params.length > 0) {
-      script += ', params=' + this.nodeParams();
+      script += `, params=${params}`;
     }
     if (this._node.spatial.hasPositions()) {
       script +=
-        ',' + this._() + 'positions=' + this._node.spatial.positions.toCode();
+        ',' +
+        (params.length > 0 ? ' ' : this._()) +
+        'positions=' +
+        this._node.spatial.positions.toCode();
     }
     script += ')';
     return script + '\n';

--- a/src/core/node/nodeSpatial.ts
+++ b/src/core/node/nodeSpatial.ts
@@ -117,8 +117,7 @@ export class FreePositions {
       'nest.spatial.free(' +
       this.spatial.node.code._(2) +
       args.join(',' + this.spatial.node.code._(2)) +
-      this.spatial.node.code._(1) +
-      ')'
+      '\n)'
     );
   }
 

--- a/src/core/parameter/parameter.ts
+++ b/src/core/parameter/parameter.ts
@@ -241,28 +241,16 @@ export class Parameter extends Config {
   }
 
   /**
-   * Format float value or array.
+   * Format value or array to string.
    */
-  format(value: any): any {
-    if (Number.isInteger(value)) {
-      return this.floatToFixed(value);
-    } else if (Array.isArray(value)) {
+  format(value: any): string {
+    if (Array.isArray(value)) {
       return `[${String(value.map((v: any) => this.format(v)))}]`;
     } else {
-      return value;
+      return JSON.stringify(value);
     }
   }
 
-  /**
-   * Fixed float value with correct amount of decimals.
-   */
-  floatToFixed(value: number): string {
-    const valString: string = JSON.stringify(value);
-    const valList: string[] = valString.split('.');
-    return value.toFixed(
-      valList.length === 2 ? Math.min(valList[1].length, 20) : 1
-    );
-  }
 
   /**
    * Write code.
@@ -274,16 +262,9 @@ export class Parameter extends Config {
       if (this._format === 'boolean') {
         // Boolean value for Python
         value = this._value ? 'True' : 'False';
-      } else if (
-        this._format === 'integer' ||
-        ['indegree', 'outdegree', 'N'].includes(this._id) // in connection
-      ) {
-        // Integer value.
-        const val = this._value as Number;
-        value = val.toFixed();
       } else {
-        // Float value or array.
-        value = this.format(this._value);
+        const val = this._value as Number;
+        value = this.format(val);
       }
     } else if (this._type.id.startsWith('numpy')) {
       const specs: string = this.specs

--- a/src/core/parameter/valueGenerator.ts
+++ b/src/core/parameter/valueGenerator.ts
@@ -48,6 +48,10 @@ export class ValueGenerator {
     return this._params;
   }
 
+  set sort(value: boolean) {
+    this._sort = value;
+  }
+
   get type(): string {
     return this._type;
   }

--- a/src/core/project/projectCode.ts
+++ b/src/core/project/projectCode.ts
@@ -63,10 +63,10 @@ export class ProjectCode extends Code {
         this._script += '\n\n# Define function getting node positions\n';
         this._script += this.defineGetNodePositions();
       }
-
-      this._script += '\n\n# Get activities\n';
-      this._script += this.response();
     }
+
+    this._script += '\n\n# Collect response\n';
+    this._script += this.response();
 
     this._hash = sha1(this._script);
   }
@@ -117,15 +117,20 @@ export class ProjectCode extends Code {
     script += this._() + '"kernel": {';
     script +=
       this._(2) + '"biological_time": nest.GetKernelStatus("biological_time")';
-    script += this._() + '},';
-    script +=
-      this._() + '"activities": ' + this._project.network.code.getActivities();
-    if (this._project.network.hasSpatialNodes()) {
+    script += this._() + '}';
+    if (this._project.network.recorders.length > 0) {
       script +=
         ',' +
         this._() +
-        '"positions": ' +
-        this._project.network.code.getNodePositions();
+        '"activities": ' +
+        this._project.network.code.getActivities();
+      if (this._project.network.hasSpatialNodes()) {
+        script +=
+          ',' +
+          this._() +
+          '"positions": ' +
+          this._project.network.code.getNodePositions();
+      }
     }
     script += this.end() + '}';
     return script + '\n';

--- a/src/core/project/projectCode.ts
+++ b/src/core/project/projectCode.ts
@@ -54,17 +54,19 @@ export class ProjectCode extends Code {
     this._script += '\n\n# Run simulation\n';
     this._script += this._project.simulation.code.simulate();
 
-    this._script +=
-      '\n\n# Define function getting activity from the recorder\n';
-    this._script += this.defineGetActivity();
+    if (this._project.network.recorders.length > 0) {
+      this._script +=
+        '\n\n# Define function getting activity from the recorder\n';
+      this._script += this.defineGetActivity();
 
-    if (this._project.network.hasSpatialNodes()) {
-      this._script += '\n\n# Define function getting node positions\n';
-      this._script += this.defineGetNodePositions();
+      if (this._project.network.hasSpatialNodes()) {
+        this._script += '\n\n# Define function getting node positions\n';
+        this._script += this.defineGetNodePositions();
+      }
+
+      this._script += '\n\n# Get activities\n';
+      this._script += this.response();
     }
-
-    this._script += '\n\n# Collect activities\n';
-    this._script += this.response();
 
     this._hash = sha1(this._script);
   }

--- a/src/core/simulation/simulationCode.ts
+++ b/src/core/simulation/simulationCode.ts
@@ -13,15 +13,14 @@ export class SimulationCode extends Code {
    * Write script for simulation kernel.
    */
   setKernelStatus(): string {
-    let script = 'nest.SetKernelStatus({';
-    script +=
-      this._() +
-      `"local_num_threads": ${this._simulation.kernel.localNumThreads},`;
-    script +=
-      this._() +
-      `"resolution": ${this.format(this._simulation.kernel.resolution)},`;
-    script += this._() + `"rng_seed": ${this._simulation.kernel.rngSeed}`;
-
+    let script = 'nest.SetKernelStatus({' + this._();
+    const specs: string[] = [];
+    specs.push(
+      `"local_num_threads": ${this._simulation.kernel.localNumThreads}`
+    );
+    specs.push(`"resolution": ${this._simulation.kernel.resolution}`);
+    specs.push(`"rng_seed": ${this._simulation.kernel.rngSeed}`);
+    script += specs.join(',' + this._());
     script += this.end() + '})';
     return script + '\n';
   }


### PR DESCRIPTION
This PR optimize parameter components and code generation.

Since NEST converts integer into float automatically (https://github.com/nest/nest-simulator/pull/2024), formatting into float in textual codes becomes obsolete.

I took the change to optimize generation algorithm for textual codes.