### PR TITLE
External config e.g. for NEST Simulator

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,0 +1,5 @@
+{
+  "NESTSimulator": {
+    "port": "7000"
+  }
+}

--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,5 @@
 {
   "NESTSimulator": {
-    "port": "7000"
+    "port": "5000"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <iframe id="NESTFrame" class="iframe" />
+    <iframe id="NESTSimulatorFrame" class="iframe" />
     <Navigation class="no-print" />
 
     <transition name="fade">
@@ -71,18 +71,36 @@ export default Vue.extend({
     };
 
     /**
-     * Keep connection to NEST Server alive.
+     * Update configs from global config.
+     *
+     * @remarks
+     * Global config is loaded in main.ts.
+     */
+    const updateConfigs = () => {
+      const config = Vue.prototype.$config || {};
+
+      // Update config for NEST Simulator
+      if (config.NESTSimulator && !core.app.NESTSimulator.config.custom) {
+        if ('url' in config.NESTSimulator) {
+          core.app.NESTSimulator.url = config.NESTSimulator.url;
+        } else {
+          core.app.NESTSimulator.updateConfig(config.NESTSimulator);
+        }
+      }
+    };
+
+    /**
+     * Keep connection to NEST Simulator alive.
      * Ping every 5 min.
      */
-    const keepConnectionToNESTServerAlive = () => {
-      core.app.nestServer
-        .check()
+    const keepConnectionToNESTSimulatorAlive = () => {
+      core.app.NESTSimulator.check()
         .then(() => {
-          const NESTFrame = document.getElementById(
-            'NESTFrame'
+          const NESTSimulatorFrame = document.getElementById(
+            'NESTSimulatorFrame'
           ) as HTMLIFrameElement;
           setInterval(() => {
-            NESTFrame.src = core.app.nestServer.url;
+            NESTSimulatorFrame.src = core.app.NESTSimulator.url;
             // NESTFrame.contentDocument.location.reload(true);
           }, 300000);
         })
@@ -96,7 +114,8 @@ export default Vue.extend({
         once: true,
       });
       core.app.init();
-      keepConnectionToNESTServerAlive();
+      updateConfigs();
+      keepConnectionToNESTSimulatorAlive();
     });
 
     return { refreshApp, state };

--- a/src/App.vue
+++ b/src/App.vue
@@ -78,7 +78,6 @@ export default Vue.extend({
      */
     const updateConfigs = () => {
       const config = Vue.prototype.$config || {};
-
       // Update config for NEST Simulator
       if (config.NESTSimulator && !core.app.NESTSimulator.config.custom) {
         if ('url' in config.NESTSimulator) {

--- a/src/assets/config/NESTSimulator.json
+++ b/src/assets/config/NESTSimulator.json
@@ -1,6 +1,6 @@
 {
   "custom": false,
   "hostname": "",
-  "port": "5000",
+  "port": "",
   "protocol": ""
 }

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -45,7 +45,7 @@
                 mailText[3] +
                 state.version +
                 mailText[4] +
-                state.serverVersion +
+                state.simulatorVersion +
                 mailText[5] +
                 state.osType +
                 mailText[6]
@@ -80,7 +80,7 @@ export default {
       license: 'MIT License',
       osType: '',
       repo: 'https://github.com/nest-desktop/nest-desktop',
-      serverVersion: core.app.nestServer.state.simulatorVersion,
+      simulatorVersion: core.app.NESTSimulator.state.simulatorVersion,
       version: core.app.version,
     });
     const mailText = [
@@ -88,16 +88,16 @@ export default {
       '%0D%0ABrowser name: ',
       '%0D%0ABrowser version: ',
       '%0D%0ANEST Desktop version: ',
-      '%0D%0ANEST Server version: ',
+      '%0D%0ANEST Simulator version: ',
       '%0D%0AOS type: ',
       '%0D%0A %2D%2D%2D%2D %0D%0A%0D%0A(your message text...)',
     ];
 
     // TODO: change to onRenderTriggered in Vue 3 to catch updates as well
     onBeforeMount(() => {
-      // Fetch the NEST Server version.
-      core.app.nestServer.check().then(() => {
-        state.serverVersion = core.app.nestServer.state.simulatorVersion;
+      // Fetch the NEST Simulator version.
+      core.app.NESTSimulator.check().then(() => {
+        state.simulatorVersion = core.app.NESTSimulator.state.simulatorVersion;
       });
 
       // Fetch the debugging information

--- a/src/components/model/ModelDocumentation.vue
+++ b/src/components/model/ModelDocumentation.vue
@@ -87,7 +87,7 @@ export default Vue.extend({
       if (!state.modelId) {
         return;
       }
-      state.url = `${core.app.nestServer.url}/api/help?return_text=true&obj=${state.modelId}`;
+      state.url = `${core.app.NESTSimulator.url}/api/help?return_text=true&obj=${state.modelId}`;
       axios
         .get(state.url)
         .then(resp => {

--- a/src/components/navigation/ModelNavList.vue
+++ b/src/components/navigation/ModelNavList.vue
@@ -68,8 +68,8 @@ export default Vue.extend({
         // Use implemented models
         state.models = implementedModels;
       } else {
-        // Fetch models from NEST Server API.
-        const url = `${core.app.nestServer.url}/api/Models`;
+        // Fetch models from NEST Simulator.
+        const url = `${core.app.NESTSimulator.url}/api/Models`;
         axios.get(url).then(resp => {
           state.models = resp.data;
         });

--- a/src/core/app.ts
+++ b/src/core/app.ts
@@ -3,7 +3,7 @@ import { AppView } from './appView';
 import { Config } from './config';
 import { DatabaseService } from './database';
 import { Model } from './model/model';
-import { NESTServer } from './backends/nest';
+import { NESTSimulator } from './backends/nestSimulator';
 import { Project } from './project/project';
 
 import { environment } from '../environments/environment';
@@ -19,7 +19,7 @@ const pad = (num: number, size: number = 2): string => {
 export class App extends Config {
   private _modelDB: DatabaseService;
   private _models: Model[] = [];
-  private _nestServer: NESTServer;
+  private _NESTSimulator: NESTSimulator;
   private _project: Project;
   private _projectDB: DatabaseService;
   private _projectRevisions: Project[] = [];
@@ -32,7 +32,7 @@ export class App extends Config {
     super('App');
     this._version = environment.VERSION;
     this._view = new AppView(this);
-    this._nestServer = new NESTServer();
+    this._NESTSimulator = new NESTSimulator();
   }
 
   get datetime(): string {
@@ -59,8 +59,8 @@ export class App extends Config {
     return this._modelDB;
   }
 
-  get nestServer(): NESTServer {
-    return this._nestServer;
+  get NESTSimulator(): NESTSimulator {
+    return this._NESTSimulator;
   }
 
   get ready(): boolean {

--- a/src/core/backends/backend.ts
+++ b/src/core/backends/backend.ts
@@ -48,11 +48,11 @@ export class Backend extends Config {
   }
 
   /**
-   * The url variable stores the NEST Server URL by splitting it into hostname
+   * The url variable stores the URL of the backend by splitting it into hostname
    * and protocol. Beware: A correct URL has to contain a '//' delimiter,
    * otherwise the empty string is used.
    *
-   * @returns NEST Server URL (or empty string if undefined)
+   * @returns the URL of the backend (or empty string if undefined)
    */
   get url(): string {
     if (
@@ -66,7 +66,7 @@ export class Backend extends Config {
   }
 
   /**
-   * The url variable stores the NEST Server URL by splitting it into hostname
+   * The url variable stores the URL of the backend by splitting it into hostname
    * and protocol. Beware: A correct URL has to contain a '//' delimiter,
    * otherwise the empty string is used.
    *

--- a/src/core/backends/nestSimulator.ts
+++ b/src/core/backends/nestSimulator.ts
@@ -1,6 +1,6 @@
 import { Backend } from './backend';
 
-export class NESTServer extends Backend {
+export class NESTSimulator extends Backend {
   private _state: any = {
     serverReady: false,
     simulatorReady: false,
@@ -8,7 +8,7 @@ export class NESTServer extends Backend {
   };
 
   constructor() {
-    super('NESTServer');
+    super('NESTSimulator');
   }
 
   get state(): any {
@@ -16,11 +16,11 @@ export class NESTServer extends Backend {
   }
 
   /**
-   * Check if the nest backend is served.
+   * Check if the NEST Simulator is serving.
    */
   check(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      // console.log('Check backend')
+      // console.log('Check NEST Simulator')
       if (this.config.hostname) {
         this.ping(
           this.url,
@@ -36,13 +36,14 @@ export class NESTServer extends Backend {
   }
 
   /**
-   * Seek the url of NEST Server.
+   * Seek the server URL of NEST Simulator.
    */
   seek(): Promise<any> {
-    // console.log('seek nest server');
+    // console.log('seek the server of NEST Simulator');
     const protocol: string = window.location.protocol;
     const hostname: string = window.location.hostname || 'localhost';
-    const hosts: string[] = [hostname + ':5000', hostname + '/nest'];
+    const port: string = this.port || '5000';
+    const hosts: string[] = [hostname + ':' + port, hostname + '/nest'];
     const hostPromises: any[] = hosts.map(
       (host: string) =>
         new Promise<void>((resolve, reject) => {
@@ -58,7 +59,7 @@ export class NESTServer extends Backend {
   }
 
   /**
-   * Ping the NEST Server.
+   * Ping the server of NEST Simulator.
    * @param url The URL which should be pinged.
    * @param callbackFail Function to execute in case of ping failure
    * @param callbackSucc Function to execute in case of ping success
@@ -68,7 +69,7 @@ export class NESTServer extends Backend {
     callbackFail: any = false,
     callbackSucc: any = false
   ): void {
-    // console.log('ping nest server');
+    // console.log('ping the server of NEST Simulator');
     this._state.serverReady = false;
 
     this.httpClient.ping(url, (req: any) => {

--- a/src/core/node/nodeCode.ts
+++ b/src/core/node/nodeCode.ts
@@ -15,10 +15,6 @@ export class NodeCode extends Code {
     return this._node.view.label;
   }
 
-  get simulatorVersion(): string {
-    return this._node.network.project.app.nestServer.state.simulatorVersion;
-  }
-
   /**
    * Write script to create node.
    */

--- a/src/core/project/project.ts
+++ b/src/core/project/project.ts
@@ -18,7 +18,7 @@ import { upgradeProject } from './projectUpgrade';
 export class Project extends Config {
   private _activityGraph: ActivityGraph;
   private _app: App; // parent
-  private _code: ProjectCode; // code script for NEST Server
+  private _code: ProjectCode; // code script for NEST Simulator
   private _createdAt: string; // when is it created in database
   private _description: string; // description about the project
   private _errorMessage = '';
@@ -420,8 +420,8 @@ export class Project extends Config {
       this._code.generate();
     }
     this._simulation.running = true;
-    return this.app.nestServer.httpClient
-      .post(this._app.nestServer.url + '/exec', {
+    return this.app.NESTSimulator.httpClient
+      .post(this._app.NESTSimulator.url + '/exec', {
         source: this._code.script,
         return: 'response',
       })
@@ -429,7 +429,7 @@ export class Project extends Config {
         let data: any;
         switch (resp.status) {
           case 0:
-            this._errorMessage = 'Failed to find NEST Server.';
+            this._errorMessage = 'Failed to find the server of NEST Simulator.';
             break;
           case 200:
             data = JSON.parse(resp.response).data;

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,9 +35,25 @@ Vue.use(VueCodemirror);
 // Production
 Vue.config.productionTip = false;
 
-new Vue({
-  router,
-  store,
-  vuetify,
-  render: h => h(App),
-}).$mount('#app');
+/**
+ * initialize app.
+ */
+const initApp = () => {
+  new Vue({
+    router,
+    store,
+    vuetify,
+    render: h => h(App),
+  }).$mount('#app');
+};
+
+// Load data for global config.
+fetch(process.env.BASE_URL + 'config.json')
+  .then(response => response.json())
+  .then(config => {
+    Vue.prototype.$config = config;
+    initApp();
+  })
+  .catch(() => {
+    initApp();
+  });

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ Vue.use(VueCodemirror);
 Vue.config.productionTip = false;
 
 /**
- * initialize app.
+ * Initialize the app.
  */
 const initApp = () => {
   new Vue({
@@ -47,13 +47,12 @@ const initApp = () => {
   }).$mount('#app');
 };
 
-// Load data for global config.
+// Load the data from public/config.json for the global config and initialize the app.
 fetch(process.env.BASE_URL + 'config.json')
   .then(response => response.json())
   .then(config => {
     Vue.prototype.$config = config;
-    initApp();
   })
-  .catch(() => {
+  .finally(() => {
     initApp();
   });

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -48,19 +48,24 @@
             <v-tooltip top open-delay="300">
               <template v-slot:activator="{ on, attrs }">
                 <v-text-field
-                  label="NEST Server URL"
-                  placeholder="https://www.my-nest-server.com:5000"
-                  v-model="state.app.nestServer.url"
+                  @change="updateNESTSimulatorConfig"
+                  label="URL of NEST Simulator"
+                  placeholder="http://127.0.0.1:5000"
+                  v-model="state.app.NESTSimulator.url"
                   v-bind="attrs"
                   v-on="on"
                 />
               </template>
               <span>
-                Please enter the URL where the NEST Server can be found at
-                (including protocol!).
+                Please enter the URL where the server of NEST Simulator can be
+                found at (including protocol!).
               </span>
             </v-tooltip>
-            <span v-if="state.nestVersion && state.nestVersion != 'unknown'">
+            <span
+              v-if="
+                state.simulatorVersion && state.simulatorVersion != 'unknown'
+              "
+            >
               <label>Response: </label>
               <v-tooltip right open-delay="300">
                 <template v-slot:activator="{ on, attrs }">
@@ -68,13 +73,16 @@
                     <v-avatar left>
                       <v-icon small v-text="'mdi-checkbox-marked-circle'" />
                     </v-avatar>
-                    NEST version: {{ state.nestVersion }}
+                    NEST version: {{ state.simulatorVersion }}
                   </v-chip>
                 </template>
-                <span>A NEST Server has been found at the given URL.</span>
+                <span
+                  >A server of NEST Simulator has been found at the given
+                  URL.</span
+                >
               </v-tooltip>
             </span>
-            <span v-else-if="state.nestVersion === 'unknown'">
+            <span v-else-if="state.simulatorVersion === 'unknown'">
               <label>Response: </label>
               <v-tooltip right open-delay="300">
                 <template v-slot:activator="{ on, attrs }">
@@ -85,7 +93,9 @@
                     <span>Unknown</span>
                   </v-chip>
                 </template>
-                <span> The NEST Server state has not been checked yet. </span>
+                <span>
+                  The server state of NEST Simulator has not been checked yet.
+                </span>
               </v-tooltip>
             </span>
             <span v-else>
@@ -100,15 +110,16 @@
                   </v-chip>
                 </template>
                 <span>
-                  The NEST Server seems to be unavailable at this URL.
+                  The server of NEST Simulator seems to be unavailable at this
+                  URL.
                 </span>
               </v-tooltip>
             </span>
           </v-card-text>
 
           <v-card-actions>
-            <v-btn @click="checkNEST">Check</v-btn>
-            <!-- <v-btn @click="() => core.app.nestServer.seek()">seek</v-btn> -->
+            <v-btn @click="checkNESTSimulator">Check</v-btn>
+            <!-- <v-btn @click="() => core.app.NESTSimulator.seek()">seek</v-btn> -->
           </v-card-actions>
         </v-card>
 
@@ -181,27 +192,27 @@ export default Vue.extend({
     const state = reactive({
       app: core.app,
       devMode: core.app.config.devMode,
-      nestVersion: 'unknown',
+      simulatorVersion: 'unknown',
       network: new Config('Network'),
       pinNav: core.app.config.pinNav,
       showHelp: core.app.project.config.showHelp,
       colorSchemes: colorSchemes,
     });
 
-    onBeforeMount(() => checkNEST());
+    onBeforeMount(() => checkNESTSimulator());
 
     /**
-     * Check if NEST is running in the backend.
+     * Check if NEST Simulator is running in the backend.
      */
-    async function checkNEST() {
-      core.app.nestServer
-        .check()
+    async function checkNESTSimulator() {
+      core.app.NESTSimulator.check()
         .catch(() => {
           // connection errors are already processed in httpClient
         })
         .finally(function () {
           // update the version (is updated as well in case of failure)
-          state.nestVersion = core.app.nestServer.state.simulatorVersion;
+          state.simulatorVersion =
+            core.app.NESTSimulator.state.simulatorVersion;
         });
     }
 
@@ -217,6 +228,14 @@ export default Vue.extend({
      */
     const updateProjectConfig = (d: any) => {
       core.app.project.updateConfig(d);
+    };
+
+    /**
+     * Update configurations for NEST Simulator.
+     */
+    const updateNESTSimulatorConfig = () => {
+      state.app.NESTSimulator.updateConfig({ custom: true });
+      checkNESTSimulator();
     };
 
     /**
@@ -236,9 +255,10 @@ export default Vue.extend({
     };
 
     return {
-      checkNEST,
+      checkNESTSimulator,
       state,
       updateAppConfig,
+      updateNESTSimulatorConfig,
       updateNetworkColorScheme,
       updateProjectConfig,
     };


### PR DESCRIPTION
This PR enables the options to change the configuration in the production.
For instance when NEST Simulator is serving at port 7000 and NEST Desktop should use this port by default.


The commits include
- [x] Rename NEST Server to NEST Simulator, seriously!
- [x] Create config file to public folder
- [x] Import config to global config before the app is initialized. 
- [x] Update config in localStorage if not customized. 