### PR TITLE
Update network graph when a new project is loaded.

### DIFF
--- a/src/components/network/NetworkEditor.vue
+++ b/src/components/network/NetworkEditor.vue
@@ -154,6 +154,7 @@ export default Vue.extend({
   },
   props: {
     networkHash: String,
+    projectId: String,
   },
   setup(props) {
     const projectView = core.app.project.view;
@@ -304,7 +305,7 @@ export default Vue.extend({
     });
 
     watch(
-      () => props.networkHash,
+      () => [props.networkHash, props.projectId],
       () => update()
     );
 

--- a/src/core/network/networkGraph/networkGraph.ts
+++ b/src/core/network/networkGraph/networkGraph.ts
@@ -78,7 +78,7 @@ export class NetworkGraph {
    * Render network graph.
    */
   render() {
-    // console.log('Update network graph');
+    this._network.consoleLog('Render network graph of ' + this._network.project.shortId);
     this._connectionGraph.render();
     this._nodeGraph.render();
   }
@@ -90,7 +90,7 @@ export class NetworkGraph {
    * This function should be called when the network is changed.
    */
   update() {
-    // console.log('Update network graph');
+    this._network.consoleLog('Update network graph of ' + this._network.project.shortId);
     this._workspace.update();
     this._connectionGraph.update();
     this._nodeGraph.update();

--- a/src/core/node/node.ts
+++ b/src/core/node/node.ts
@@ -4,6 +4,7 @@ import { Activity } from '../activity/activity';
 import { AnalogSignalActivity } from '../activity/analogSignalActivity';
 import { Config } from '../common/config';
 import { Connection } from '../connection/connection';
+import { consoleLog } from '../common/logger';
 import { Model } from '../model/model';
 import { ModelParameter } from '../parameter/modelParameter';
 import { Network } from '../network/network';
@@ -217,6 +218,10 @@ export class Node extends Config {
 
   get view(): NodeView {
     return this._view;
+  }
+
+  consoleLog(text: string): void {
+    consoleLog(this, text, 6);
   }
 
   /**

--- a/src/core/node/nodeGraph/nodeGraph.ts
+++ b/src/core/node/nodeGraph/nodeGraph.ts
@@ -68,7 +68,7 @@ export class NodeGraph {
     const nodes: d3.Selection<any, any, any, any> = this._networkGraph.selector
       .select('g#nodes')
       .selectAll('g.node')
-      .data(this.network.nodes, (n: Node) => n.hash);
+      .data(this.network.nodes, (n: Node) => (n.network.project.id + n.hash));
 
     nodes
       .enter()

--- a/src/core/node/nodeState.ts
+++ b/src/core/node/nodeState.ts
@@ -15,6 +15,7 @@ export class NodeState {
    * Focus this node.
    */
   focus(forced: boolean = false): void {
+    this._node.consoleLog('Focus node of ' + this._node.network.project.shortId);
     const networkState = this._node.network.state;
     if (forced) {
       networkState.resetFocus();
@@ -30,9 +31,10 @@ export class NodeState {
   }
 
   /**
-   * Select thisnode.
+   * Select this node.
    */
   select(forced: boolean = false): void {
+    this._node.consoleLog('Select node of ' + this._node.network.project.shortId);
     const networkState = this._node.network.state;
     if (forced) {
       networkState.resetSelection();

--- a/src/core/project/project.ts
+++ b/src/core/project/project.ts
@@ -284,7 +284,7 @@ export class Project {
    * Add network to the history list.
    */
   commitNetwork(network: Network): void {
-    this.consoleLog('Commit network of ' + network.project.name);
+    this.consoleLog('Commit network of ' + network.project.id.slice(0, 6));
 
     // Remove networks after the current.
     this._networkRevisions = this._networkRevisions.slice(

--- a/src/core/project/project.ts
+++ b/src/core/project/project.ts
@@ -132,6 +132,10 @@ export class Project {
     return this._simulation;
   }
 
+  get shortId(): string {
+    return this._id.slice(0, 6);
+  }
+
   get state(): UnwrapRef<any> {
     return this._state;
   }
@@ -284,7 +288,7 @@ export class Project {
    * Add network to the history list.
    */
   commitNetwork(network: Network): void {
-    this.consoleLog('Commit network of ' + network.project.id.slice(0, 6));
+    this.consoleLog('Commit network of ' + network.project.shortId);
 
     // Remove networks after the current.
     this._networkRevisions = this._networkRevisions.slice(

--- a/src/core/project/projectStore.ts
+++ b/src/core/project/projectStore.ts
@@ -201,7 +201,7 @@ export class ProjectStore {
    * Initialize project or project revision from the list.
    */
   initProject(id: string = '', rev: string = ''): Promise<any> {
-    this.consoleLog(`Initialize project: id=${id}, rev=${rev}`);
+    this.consoleLog(`Initialize project: id=${id.slice(0, 6)}, rev=${rev}`);
     return new Promise<any>(resolve => {
       try {
         if (id && rev) {

--- a/src/core/project/projectView.ts
+++ b/src/core/project/projectView.ts
@@ -118,7 +118,7 @@ export class ProjectView extends Config {
    * Initialize project view
    */
   async init(): Promise<any> {
-    this.consoleLog('Initialize project: ' + this._state.projectId);
+    this.consoleLog('Initialize project: ' + this._state.projectId.slice(0, 6));
 
     if (this._app.backends.insiteAccess.state.version.insite == null) {
       this.updateConfig({ simulateWithInsite: false });

--- a/src/views/Project.vue
+++ b/src/views/Project.vue
@@ -271,6 +271,7 @@
         >
           <NetworkEditor
             :networkHash="projectView.state.project.network.state.hash"
+            :projectId="projectView.state.projectId"
           />
         </div>
       </transition>


### PR DESCRIPTION
This PR fixes the updating of the network graph when another project is loaded (`projectId` is changed).

It fixes the issue #162 and #164.

