### PR TITLE
Add slider for time in animation controller

### DIFF
--- a/src/components/activity/activityAnimation/ActivityAnimationController.vue
+++ b/src/components/activity/activityAnimation/ActivityAnimationController.vue
@@ -99,7 +99,7 @@
       </v-card-text>
     </v-card>
 
-    <!-- <v-card flat tile>
+    <v-card flat tile>
       <v-card-text class="pa-0">
         <ParameterEdit
           :options="{
@@ -107,12 +107,13 @@
             min: 1,
             max: state.graph.frames.length - 1,
             label: 'Current time',
+            readonly: state.graph.config.frames.speed !== 0,
             unit: 'ms',
           }"
           :value.sync="state.graph.frameIdx"
         />
       </v-card-text>
-    </v-card> -->
+    </v-card>
 
     <v-card flat tile>
       <v-subheader v-text="'Frames'" />

--- a/src/components/parameter/ParameterEdit.vue
+++ b/src/components/parameter/ParameterEdit.vue
@@ -271,8 +271,8 @@
                     <v-row class="mx-0 py-1">
                       <v-col class="text-center" cols="2">
                         <v-icon
-                          :small="state.options.iconSize != null ? true : false"
-                          :large="state.options.iconSize != null ? false : true"
+                          :small="state.options.iconSize === 'small'"
+                          :large="state.options.iconSize === 'large'"
                           right
                           v-text="
                             state.options.rules[0].includes('info')

--- a/src/components/parameter/ParameterEdit.vue
+++ b/src/components/parameter/ParameterEdit.vue
@@ -247,6 +247,7 @@
                 :min="state.options.min || 0"
                 :persistent-hint="state.message.length > 0"
                 :rules="rules"
+                :readonly="state.options.readonly || false"
                 :step="state.options.step || 1"
                 :thumb-color="state.color"
                 :value="state.value"
@@ -280,7 +281,10 @@
                 </template>
                 <template #prepend>
                   <v-btn
-                    :disabled="state.value <= state.options.min && false"
+                    :disabled="
+                      (state.value <= state.options.min && false) ||
+                      state.options.readonly
+                    "
                     @click="decrement"
                     icon
                     small
@@ -289,12 +293,16 @@
                       :color="color"
                       class="slider-icon"
                       v-text="'mdi-minus'"
+                      v-show="!state.options.readonly"
                     />
                   </v-btn>
                 </template>
                 <template #append>
                   <v-btn
-                    :disabled="state.value >= state.options.max && false"
+                    :disabled="
+                      (state.value >= state.options.max && false) ||
+                      state.options.readonly
+                    "
                     @click="increment"
                     icon
                     small
@@ -303,9 +311,11 @@
                       :color="color"
                       class="slider-icon"
                       v-text="'mdi-plus'"
+                      v-show="!state.options.readonly"
                     />
                   </v-btn>
                   <v-text-field
+                    :readonly="state.options.readonly"
                     :step="state.options.step || 1"
                     :value="state.value"
                     @blur="e => paramChange(e.target.value)"


### PR DESCRIPTION
This PR adds time slider for animation controller.

The slider for current time:
![screenshot-localhost_8001-2021 12 07-14_57_11](https://user-images.githubusercontent.com/620984/145042362-0a21a7a7-008c-4adf-9782-69fb169b290f.png)