### PR TITLE
vue.config.js: Optimize compile performance

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -22,7 +22,11 @@ module.exports = {
     // copy the options from the original ones, but modify memory and CPUs
     const newForkTsCheckerOptions = existingForkTsChecker.options;
     newForkTsCheckerOptions.memoryLimit = 8192;
-    newForkTsCheckerOptions.workers = require('os').cpus().length - 1;
+    console.log("process.env.CI = " + process.env.CI);
+    if (process.env.CI)
+      newForkTsCheckerOptions.workers = require('os').cpus().length + 2;
+    else
+      newForkTsCheckerOptions.workers = require('os').cpus().length - 1;
     config.plugins.push(
       new ForkTsCheckerWebpackPlugin(newForkTsCheckerOptions)
     );


### PR DESCRIPTION
This commit adds the option to pass with an enviroment variable "CI" wheter the compile process is run in a CI environment or not (like on a personal system where other processes need resources, too).