### PR TITLE
Only slice projectId if existed.

### DIFF
--- a/src/core/project/projectView.ts
+++ b/src/core/project/projectView.ts
@@ -118,7 +118,7 @@ export class ProjectView extends Config {
    * Initialize project view
    */
   async init(): Promise<any> {
-    if (this._state.projectId != undefined) {
+    if (this._state.projectId != null) {
       this.consoleLog(
         'Initialize project: ' + this._state.projectId.slice(0, 6)
       );

--- a/src/core/project/projectView.ts
+++ b/src/core/project/projectView.ts
@@ -118,7 +118,11 @@ export class ProjectView extends Config {
    * Initialize project view
    */
   async init(): Promise<any> {
-    this.consoleLog('Initialize project: ' + this._state.projectId.slice(0, 6));
+    if (this._state.projectId != undefined) {
+      this.consoleLog(
+        'Initialize project: ' + this._state.projectId.slice(0, 6)
+      );
+    }
 
     if (this._app.backends.insiteAccess.state.version.insite == null) {
       this.updateConfig({ simulateWithInsite: false });


### PR DESCRIPTION
It fixes the bug in creating a new project. A projectId might be not existed.