### PR TITLE
Fix showing model doc in node menu

### DIFF
--- a/src/components/model/ModelDocumentation.vue
+++ b/src/components/model/ModelDocumentation.vue
@@ -55,6 +55,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import { onMounted, watch } from '@vue/composition-api';
 
 import core from '@/core';
 
@@ -63,12 +64,28 @@ import core from '@/core';
  */
 export default Vue.extend({
   name: 'ModelDocumentation',
-  setup() {
+  props: {
+    id: String,
+  },
+  setup(props) {
     const modelView = core.app.model.view;
     const NESTVersion = 'v3.1';
     const NESTDocURL = () => {
       return `https://nest-simulator.readthedocs.io/en/${NESTVersion}/models/${modelView.state.modelId}.html`;
     };
+
+    onMounted(() => {
+      modelView.state.modelId = props.id;
+      modelView.updateModelDoc();
+    });
+
+    watch(
+      () => props.id,
+      (id: string) => {
+        modelView.state.modelId = id;
+        modelView.updateModelDoc();
+      }
+    );
 
     return { NESTDocURL, modelView };
   },

--- a/src/views/Model.vue
+++ b/src/views/Model.vue
@@ -150,6 +150,7 @@
 
           <v-card
             flat
+            tile
             v-if="
               modelView.state.tool.name === 'modelParameterInput' &&
               modelView.state.model


### PR DESCRIPTION
It fixes a small bug to show model doc.
The documentation of the model displayed in the node menu was somehow broken.