### PR TITLE
Use hash for router history

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,7 +4,7 @@ import Router from 'vue-router';
 Vue.use(Router);
 
 export default new Router({
-  mode: process.env.IS_ELECTRON ? 'hash' : 'history',
+  mode: 'hash',
   base: process.env.BASE_URL,
   routes: [
     {


### PR DESCRIPTION
When testing in production in docker image reloading page doesn't work. 

So, I decide to use hash for router history.

