### PR TITLE
Add F-I curve for neuron models

### DIFF
--- a/src/assets/projects/model-f-i-curve.json
+++ b/src/assets/projects/model-f-i-curve.json
@@ -1,0 +1,79 @@
+{
+  "activityGraph": {
+    "panels": [
+      { "model": { "id": "senderSpikeCountPlot" } },
+      { "model": { "id": "senderMeanISIPlot" } }
+    ]
+  },
+  "name": "spike activity",
+  "network": {
+    "nodes": [
+      {
+        "model": "iaf_psc_alpha",
+        "size": 1000,
+        "view": { "position": { "x": 0, "y": 25 } }
+      },
+      {
+        "model": "dc_generator",
+        "params": [
+          {
+            "id": "amplitude",
+            "value": 0,
+            "visible": true,
+            "type": {
+              "icon": "mdi-code-brackets",
+              "id": "numpy.arange",
+              "label": "ranged array",
+              "specs": [
+                {
+                  "default": 0,
+                  "id": "start",
+                  "optional": true,
+                  "label": "start",
+                  "value": 1
+                },
+                { "id": "stop", "label": "stop", "value": 1002 },
+                {
+                  "default": 1,
+                  "id": "step",
+                  "optional": true,
+                  "label": "step",
+                  "value": 1
+                }
+              ]
+            }
+          },
+          { "id": "start", "value": 0, "visible": false },
+          { "id": "stop", "value": 1000, "visible": false }
+        ],
+        "size": 1000,
+        "view": { "position": { "x": -150, "y": -25 } }
+      },
+      {
+        "model": "spike_recorder",
+        "params": [
+          { "id": "start", "value": 0, "visible": false },
+          { "id": "stop", "value": 10000, "visible": false }
+        ],
+        "size": 1,
+        "view": { "position": { "x": 150, "y": -25 } }
+      }
+    ],
+    "connections": [
+      {
+        "rule": "one_to_one",
+        "source": 1,
+        "target": 0
+      },
+      {
+        "source": 0,
+        "target": 2
+      }
+    ]
+  },
+  "simulation": {
+    "kernel": { "localNumThreads": 1, "resolution": 0.1, "rngSeed": 1 },
+    "time": 1000
+  },
+  "version": "3.1.0"
+}

--- a/src/core/model/modelView.ts
+++ b/src/core/model/modelView.ts
@@ -193,10 +193,10 @@ export class ModelView {
     if (elementType !== 'neuron') {
       return;
     }
-    const node: Node = this._state.project.network.nodes[1];
-    node.modelId = this._state.modelId;
-    node.params = this._state.model.params;
-    node.params.forEach((param: any) => (param.state.visible = true));
+    const neuron: Node = this._state.project.network.neurons[0];
+    neuron.modelId = this._state.modelId;
+    neuron.params = this._state.model.params;
+    neuron.params.forEach((param: any) => (param.state.visible = true));
     this._state.project.code.generate();
   }
 
@@ -337,9 +337,11 @@ export class ModelView {
           });
       })
       .catch(() => {
-        this._state.doc.blocks = [{
-          content: `Sorry, there is no help for '${this._state.modelId}'.`,
-        }];
+        this._state.doc.blocks = [
+          {
+            content: `Sorry, there is no help for '${this._state.modelId}'.`,
+          },
+        ];
       });
   }
 

--- a/src/views/Model.vue
+++ b/src/views/Model.vue
@@ -278,6 +278,11 @@ export default Vue.extend({
         icon: 'mdi-chart-line',
       },
       {
+        id: 'model-f-i-curve',
+        name: 'F-I curve',
+        icon: 'mdi-chart-line',
+      },
+      {
         id: 'spike-activity',
         name: 'spike activity',
         icon: 'mdi-chart-scatter-plot',


### PR DESCRIPTION
From students feedback, it is useful to show F-I curve of neurons in NEST Desktop directly.

It depends on #280.