### PR TITLE
Remove parseFloat

### DIFF
--- a/src/core/parameter/parameter.ts
+++ b/src/core/parameter/parameter.ts
@@ -184,7 +184,7 @@ export class Parameter extends Config {
   }
 
   set value(value: any) {
-    this._value = this.isNumeric(value) ? parseFloat(value) : value;
+    this._value = value;
   }
 
   get visible(): boolean {
@@ -196,13 +196,6 @@ export class Parameter extends Config {
    */
   isConstant(): boolean {
     return this._type.id === 'constant';
-  }
-
-  /**
-   * Check if this parameter is a number.
-   */
-  isNumeric(value: any): boolean {
-    return /^-?\d+$/.test(value);
   }
 
   /**


### PR DESCRIPTION
It is not necessary to convert value in float, because NEST accepts Interger.

However, in array input it accidentally converts array of a single unit into number.
As consequence parseFloat is removed.

It still works with number input as well as array input.