### PR TITLE
Fix not showing stats for low spike activity

### DIFF
--- a/src/components/activity/activityStats/ActivityStatsAnalog.vue
+++ b/src/components/activity/activityStats/ActivityStatsAnalog.vue
@@ -136,8 +136,8 @@ export default Vue.extend({
           const d: any = data[id];
           return {
             id,
-            mean: d.length === 0 ? NaN : d3.mean(d).toFixed(2),
-            std: d.length === 0 ? NaN : d3.deviation(d).toFixed(2),
+            mean: d.length > 0 ? d3.mean(d).toFixed(2) : NaN,
+            std: d.length > 0 ? d3.deviation(d).toFixed(2): NaN,
           };
         });
         state.activityHash = state.activity.hash;


### PR DESCRIPTION
This PR fixes bug in activity stats.

It doesn't show any rows when no or single spikes occurred in each neuron.

