### PR TITLE
Docs reference model about

### DIFF
--- a/docs/reference/sections/about.rst
+++ b/docs/reference/sections/about.rst
@@ -1,0 +1,9 @@
+About view
+==========
+
+This view shows the program info about NEST Desktop.
+In the center, you can see a short explanation as well as the technical details.
+
+At the bottom, you will find further references for background information.
+
+In a slightly varied form this view is used as the landing page (containing buttons to start a new project or load one) when yor start NEST Desktop.

--- a/docs/reference/sections/model.rst
+++ b/docs/reference/sections/model.rst
@@ -1,0 +1,53 @@
+Model view
+==========
+
+Left sidebar
+------------
+
+In this view you can manage your models.
+In the left sidebar, a list of the available models is shown.
+You can search the models list in the search bar on top of the list.
+Below the search bar, you have the possibility to select the following filter options regarding node type and model source:
+
+Installed
+  selects only models which are installed locally
+GitHub
+  selects only models which are available on GitHub
+Neuron
+  selects all neuron models
+Stimulator
+  selects all stimulator models
+Recorder
+  selects all recorder models
+Synapse
+  selects all synapse models
+
+
+Please be aware that the model source filters work like a logical AND, while the node type filters work like a logical OR.
+The node and source filters are combined with a logical AND (e.g. "(Installed AND GitHub) AND (Neuron OR Simulator)").
+
+Center area
+-----------
+
+In the center area, the content for the model is displayed.
+The bar on top contains three selectors on the left side,
+which allow to switch between different content for the center area:
+
+DOC
+  model documentation (section contains a reference to the content within the NEST documentation in the upper right corner)
+EXPLORER
+  diagram(s) of the simulation results for an exemplary network containing this model (code can be found in the right sidebar)
+EDITOR
+  input fields to adjust all parameter settings, including value, value range, displayed unit and label, but also the settings for the input field in NEST Desktop
+
+Right sidebar
+-------------
+
+Here you find the following three icon buttons in the sidebar to dislay these information:
+
+Defaults
+  default values for all parameters (even for some which cannot be altered in NEST Desktop)
+Model
+  input fields to change the parameter values (options can be adjusted in the "EDITOR" section of the center area)
+Code
+  code for the exemplary network which is used to generate the diagrams in the "EXPLORER" section of the center area

--- a/docs/reference/sections/model.rst
+++ b/docs/reference/sections/model.rst
@@ -5,7 +5,7 @@ Left sidebar
 ------------
 
 In this view you can manage your models.
-In the left sidebar, a list of the available models is shown.
+The left sidebar shows a list of the available models.
 You can search the models list in the search bar on top of the list.
 Below the search bar, you have the possibility to select the following filter options regarding node type and model source:
 
@@ -29,7 +29,7 @@ The node and source filters are combined with a logical AND (e.g. "(Installed AN
 Center area
 -----------
 
-In the center area, the content for the model is displayed.
+The center area displays the content for the model.
 The bar on top contains three selectors on the left side,
 which allow to switch between different content for the center area:
 


### PR DESCRIPTION
Adds the "About" and "Model" views to the reference section (both not included in any toctree yet).