### PR TITLE
Extend the documentation with some missing parts of v3.1

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -53,6 +53,7 @@ Contents
   developer/preparation
   developer/coding-conventions
   developer/development
+  developer/continuous-integration
   developer/production
   developer/command-API
   developer/user-doc

--- a/docs/developer/continuous-integration.rst
+++ b/docs/developer/continuous-integration.rst
@@ -1,24 +1,41 @@
-Continuous integration (CI) with GitLab
-=======================================
+Continuous integration (CI)
+===========================
 
+GitHub
+------
 
-Since the source code of NEST Desktop is mirrored (`.github/workflows/ebrains-push.yml`)
-to `EBRAINS GitLab <https://gitlab.ebrains.eu/nest/nest-desktop>`__,
-we are able to setup automated CI systems for the compilation and the deployment.
-You can find the configuration in `.gitlab-ci.yml`. It consists of two stages, `build` and `deploy`.
+Since the NEST Desktop team has only restricted access to the CI resources of GitHub,
+the source code of NEST Desktop is mirrored (``.github/workflows/ebrains-push.yml``)
+to the `EBRAINS GitLab <https://gitlab.ebrains.eu/nest/nest-desktop>`__,
+where we are able to use automated CI systems for the compilation and the deployment.
+We use only a small GitHub CI setup to transfer the code to the EBRAINS GitLab
+and execute the compute-intensive workloads there.
 
-In each stage, we prepared two parallel pipelines in which jobs will be executed when a specific branch is pushed:
+GitLab
+------
 
-- the development pipeline for the `dev` branch to check the functional operation of the CI (later with testing).
+You can find the configuration in `.gitlab-ci.yml`.
+It consists of two stages, `build` and `deploy`.
+
+In each stage, we prepared two parallel pipelines in which jobs will be executed
+when a specific branch is pushed:
+
+- the development pipeline for the `dev` branch to check the functional operation of the CI (in the future with testing) and
 - the production pipeline for the `main` branch when NEST Desktop is released.
 
-In the build stage CI uses `Node.js` to produce NEST Desktop and store it in the `nest_desktop/app` folder.
+In the build stage, the CI pipeline  uses `Node.js` to produce NEST Desktop
+and to store it in the `nest_desktop/app` folder.
 
-In the deploy stage the CI deploys NEST Desktop as a Python package
-and as Docker images for `EBRAINS Harbor <https://docker-registry.ebrains.eu>`__` (the Docker container registry of EBRAINS)
-and `Docker Hub <https://hub.docker.com>`__`.
+In the deploy stage, the CI deploys NEST Desktop as a Python package
+and as Docker images for `EBRAINS Harbor <https://docker-registry.ebrains.eu>`__
+(the Docker container registry of EBRAINS)
+and `Docker Hub <https://hub.docker.com>`__.
 All jobs in the deploy stage depend on the job of the build stage being executed successfully.
 
 Each executable job of the development and production pipelines has a base job,
-so that the job scripts in both cases are identical
+so that the job scripts in both cases seem to be identical,
 but they only differ in the version variable for the Python package and the Docker image.
+
+.. note::
+   You can check these scripts also for commands if you want to execute single build steps
+   manually on your machine.

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -1,5 +1,5 @@
-|developer| How to develop NEST Desktop
-=======================================
+|developer| Develop NEST Desktop
+================================
 
 This is the developer guide, providing more detail on how to develop NEST Desktop.
 

--- a/docs/developer/production.rst
+++ b/docs/developer/production.rst
@@ -6,7 +6,7 @@ publish them on various platforms.
 Some are discussed below.
 
 .. note::
-   Please be aware that a lot of steps are already covered by our GitLab CI process.
+   Please be aware that a lot of steps are already covered by our `GitLab CI process <continuous-integration.html#gitlab>`__.
    Therefore, we recommend to inspect the `.yml` files together with this chapter.
    It might also be helpful to have a look at the commands defined in `project.json`.
 

--- a/docs/developer/production.rst
+++ b/docs/developer/production.rst
@@ -1,5 +1,17 @@
-Build and publish package
-=========================
+Build and publish
+=================
+
+Currently, we build NEST Desktop for multiple targets and
+publish them on various platforms.
+Some are discussed below.
+
+.. note::
+   Please be aware that a lot of steps are already covered by our GitLab CI process.
+   Therefore, we recommend to inspect the `.yml` files together with this chapter.
+   It might also be helpful to have a look at the commands defined in `project.json`.
+
+Python Package Index (PyPI)
+---------------------------
 
 .. image:: ../_static/img/logo/pypi-logo-large.svg
   :width: 240px
@@ -65,3 +77,10 @@ Do not forget to commit the changes you made and set a new version tag in git.
 
   git tag -a v3.0 -m 'v3.0.0'
   git push --tags
+
+
+Electron and Snap
+-----------------
+
+In `package.json`, there are also yarn commands configured to build an Electron app.
+If you want to build a Snap package, please have a look into `.gitlab-ci.yml`.

--- a/docs/developer/semantic-version.rst
+++ b/docs/developer/semantic-version.rst
@@ -4,7 +4,10 @@ The semantic versioning
 During the course of development, the implementation of (new) features in NEST Desktop will be reviewed for compatibility.
 In this concept a general rule of the semantic versioning NEST Desktop was introduced
 that the operational capability of the application can be guaranteed.
-Please be aware of the differences to the official `Semantic versioning <https://semver.org/>`__ standard!
+
+.. warning::
+   Please be aware of the differences to the official `Semantic versioning <https://semver.org/>`__ standard!
+
 The formal convention of the version releases for specifying compatibility in NEST Desktop uses a three-part number:
 
 **A major number**

--- a/docs/lecturer/index.rst
+++ b/docs/lecturer/index.rst
@@ -1,5 +1,5 @@
-|lecturer| Using NEST Desktop in a course
-=========================================
+|lecturer| Use NEST Desktop in a course
+=======================================
 
 This section gives directions for lecturers who want to teach computational neuroscience with NEST Desktop.
 Using computer simulations, students are able to explore models

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -21,6 +21,8 @@ At the bottom it shows a short description of NEST Desktop (left) and some usefu
   :target: #getting-started
   :width: 100%
 
+|br|
+
 .. note::
    You can reload the page if NEST Desktop has somehow crashed.
 
@@ -318,14 +320,14 @@ It is useful to give project a proper name so that you can recognize your projec
 Below the search field it shows a list of the projects.
 Clicking with right mouse button on a project item
 shows a menu with options to reload, duplicate, export or delete a project.
-Using a right click on the button with the brain icon (labelled :guilabel`Projects`)
+Using a right click on the button with the brain icon (labelled :guilabel:`Projects`)
 in the outer left sidebar, you can open the projects menu containing actions for all projects.
 In the projects menu, you can find methods to reload, export, import, delete
 or reset single or multiple projects.
 It is possible to import projects from different sources.
 The same holds for exporting projects:
-You can choose between :guilabel`File` (local storage), :guilabel`GitHub` and
-:guilabel`URL` (meaning other URLS than GitHub URLs).
+You can choose between :guilabel:`File` (local storage), :guilabel:`GitHub` and
+:guilabel:`URL` (meaning other URLS than GitHub URLs).
 
 .. warning::
    Unless you click on the save button, the project is not stored in the database of the web page cookie

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -318,8 +318,14 @@ It is useful to give project a proper name so that you can recognize your projec
 Below the search field it shows a list of the projects.
 Clicking with right mouse button on a project item
 shows a menu with options to reload, duplicate, export or delete a project.
+Using a right click on the button with the brain icon (labelled :guilabel`Projects`)
+in the outer left sidebar, you can open the projects menu containing actions for all projects.
 In the projects menu, you can find methods to reload, export, import, delete
 or reset single or multiple projects.
+It is possible to import projects from different sources.
+The same holds for saving projects:
+You can choose between :guilabel`File` (local storage), :guilabel`GitHub` and
+:guilabel`URL` (meaning other URLS than GitHub URLs).
 
 .. note::
    Unless you click on the save button, the project is not stored in the database of the web page cookie

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -323,15 +323,19 @@ in the outer left sidebar, you can open the projects menu containing actions for
 In the projects menu, you can find methods to reload, export, import, delete
 or reset single or multiple projects.
 It is possible to import projects from different sources.
-The same holds for saving projects:
+The same holds for exporting projects:
 You can choose between :guilabel`File` (local storage), :guilabel`GitHub` and
 :guilabel`URL` (meaning other URLS than GitHub URLs).
 
-.. note::
+.. warning::
    Unless you click on the save button, the project is not stored in the database of the web page cookie
    and is lost when you reload the page!
 
-   An important remark is that it stores only projects with neuronal networks in that database,
+   You should export projects that you want to keep: If you refresh your browser
+   or delete the wep page cookie, the project will be lost!
+
+   Another important remark is that NEST Desktop stores only projects
+   with neuronal networks in the cookie database,
    but all activity will be lost after page reload!
 
 


### PR DESCRIPTION
This PR adds/polishes some of the points which are still open in the GitHub project for NEST Desktop 3.1, namely
- [ ] Electron, Snap -> alpha stage
- [ ] testing (unit / e2e) -> alpha stage (also developer Docs)

and multiple other fixes.