### PR TITLE
Prepare simulation button

### DIFF
--- a/src/components/simulation/SimulationButton.vue
+++ b/src/components/simulation/SimulationButton.vue
@@ -10,7 +10,11 @@
           outlined
         >
           <v-icon left>mdi-play</v-icon>
-          Simulate
+          <span
+            v-if="state.project.simulation.code.runSimulation"
+            v-text="'Simulate'"
+          />
+          <span v-else v-text="'Prepare'" />
         </v-btn>
       </template>
       <v-list dense>


### PR DESCRIPTION
It shows `Prepare` when no `simulate()` existed in the code.