### PR TITLE
Fix changing synaptic weight

### DIFF
--- a/src/core/node/node.ts
+++ b/src/core/node/node.ts
@@ -520,7 +520,7 @@ export class Node extends Config {
         (param: SynapseParameter) => param.id === 'weight'
       );
       weight.value = (term === 'inhibitory' ? -1 : 1) * Math.abs(weight.value);
-      weight.visible = true;
+      weight.state.visible = true;
     });
     this.nodeChanges();
   }


### PR DESCRIPTION
The bug appears when set synaptic weight value. 
It tries to make the parameter visible, which is only a getter.

Fixes #380.