### PR TITLE
Fix param format

### DIFF
--- a/src/assets/config/Connection.json
+++ b/src/assets/config/Connection.json
@@ -52,6 +52,7 @@
       "label": "fixed indegree",
       "params": [
         {
+          "format": "integer",
           "id": "indegree",
           "input": "valueSlider",
           "label": "indegree",
@@ -60,16 +61,6 @@
           "step": 1,
           "value": 1,
           "visible": true
-        },
-        {
-          "id": "p",
-          "input": "valueSlider",
-          "label": "p",
-          "max": 1.0,
-          "min": 0.01,
-          "step": 0.01,
-          "value": 0.1,
-          "visible": false
         },
         {
           "id": "allow_autapses",
@@ -92,6 +83,7 @@
       "label": "fixed outdegree",
       "params": [
         {
+          "format": "integer",
           "id": "outdegree",
           "input": "valueSlider",
           "label": "outdegree",
@@ -100,16 +92,6 @@
           "step": 1,
           "value": 1,
           "visible": true
-        },
-        {
-          "id": "p",
-          "input": "valueSlider",
-          "label": "p",
-          "max": 1.0,
-          "min": 0.01,
-          "step": 0.01,
-          "value": 0.1,
-          "visible": false
         },
         {
           "id": "allow_autapses",
@@ -132,6 +114,7 @@
       "label": "fixed total number",
       "params": [
         {
+          "format": "integer",
           "id": "N",
           "input": "valueSlider",
           "label": "N",
@@ -167,6 +150,7 @@
       "label": "pairwise Bernoulli",
       "params": [
         {
+          "format": "float",
           "id": "p",
           "input": "valueSlider",
           "label": "p",

--- a/src/assets/config/Node.json
+++ b/src/assets/config/Node.json
@@ -15,6 +15,7 @@
     }
   },
   "size": {
+    "format": "integer",
     "id": "n",
     "input": "valueSlider",
     "label": "population size",

--- a/src/assets/config/SimulationKernel.json
+++ b/src/assets/config/SimulationKernel.json
@@ -9,6 +9,7 @@
       "value": 1
     },
     {
+      "format": "integer",
       "id": "rngSeed",
       "input": "valueSlider",
       "label": "seed of random number generator",

--- a/src/components/project/ProjectLabBook.vue
+++ b/src/components/project/ProjectLabBook.vue
@@ -138,7 +138,7 @@
                         <v-spacer />
                         <span
                           class="mx-1 font-weight-bold"
-                          v-text="param.toCode()"
+                          v-text="param.code"
                         />
                         <span
                           style="min-width: 24px"

--- a/src/core/connection/connection.ts
+++ b/src/core/connection/connection.ts
@@ -20,6 +20,7 @@ enum Rule {
   FixedTotalNumber = 'fixed_total_number',
   OneToOne = 'one_to_one',
   PairwiseBernoulli = 'pairwise_bernoulli',
+  symmetricPairwiseBernoulli = 'symmetric_pairwise_bernoulli',
 }
 
 export class Connection extends Config {

--- a/src/core/node/nodeSpatial/freePositions.ts
+++ b/src/core/node/nodeSpatial/freePositions.ts
@@ -114,7 +114,7 @@ export class FreePositions {
   }
 
   /**
-   * Write code for free positons for Python.
+   * Generate the Python code for free (i.e. non-grid) positions.
    */
   toPythonCode(): string {
     const template = require(`./freePositions.code`).default;

--- a/src/core/node/nodeSpatial/freePositions.ts
+++ b/src/core/node/nodeSpatial/freePositions.ts
@@ -114,9 +114,9 @@ export class FreePositions {
   }
 
   /**
-   * Write code for free positons.
+   * Write code for free positons for Python.
    */
-  toCode(): string {
+  toPythonCode(): string {
     const template = require(`./freePositions.code`).default;
     const rendered = Mustache.render(template, this);
     return rendered;

--- a/src/core/node/nodeSpatial/gridPositions.ts
+++ b/src/core/node/nodeSpatial/gridPositions.ts
@@ -108,9 +108,9 @@ export class GridPositions {
   }
 
   /**
-   * Write code for grid positons.
+   * Write code for grid positons for Python.
    */
-  toCode(): string {
+  toPythonCode(): string {
     return `nest.spatial.grid(${JSON.stringify(this._shape)})`;
   }
 

--- a/src/core/node/nodeSpatial/gridPositions.ts
+++ b/src/core/node/nodeSpatial/gridPositions.ts
@@ -108,7 +108,7 @@ export class GridPositions {
   }
 
   /**
-   * Write code for grid positons for Python.
+   * Generate the Python code for grid positions, i.e. non-free positions.
    */
   toPythonCode(): string {
     return `nest.spatial.grid(${JSON.stringify(this._shape)})`;

--- a/src/core/node/nodeSpatial/nodeSpatial.ts
+++ b/src/core/node/nodeSpatial/nodeSpatial.ts
@@ -17,7 +17,7 @@ export class NodeSpatial extends Config {
   }
 
   get code(): string {
-    return this.positions ? this.positions.toCode() : '';
+    return this.positions ? this.positions.toPythonCode() : '';
   }
 
   get hash(): string {

--- a/src/core/parameter/parameter.ts
+++ b/src/core/parameter/parameter.ts
@@ -364,6 +364,7 @@ export class Parameter extends Config {
         // Float value
         value = this.toFixed(this._value as number);
       } else if (typeof this._value === 'string') {
+      // TODO: this condition should be checked if it is really possible 
         // String value
         value = this._value as string;
       } else if (typeof this._value === 'boolean') {

--- a/src/core/parameter/parameter.ts
+++ b/src/core/parameter/parameter.ts
@@ -24,6 +24,7 @@ type parentTypes =
 
 export class Parameter extends Config {
   private _factors: string[]; // not functional yet
+  private _format: string;
   private _id: string;
   private _idx: number; // generative
   private _input: string;
@@ -59,6 +60,7 @@ export class Parameter extends Config {
     this._factors = param.factors || [];
     this._type = param.type || { id: 'constant' };
 
+    this._format = param.format || '';
     this._input = param.input;
     this._items = param.items || [];
     this._label = param.label || param.id;
@@ -71,11 +73,15 @@ export class Parameter extends Config {
   }
 
   get code(): string {
-    return this.toCode();
+    return this.toPythonCode();
   }
 
   get disabled(): boolean {
     return this._state.disabled;
+  }
+
+  get format(): string {
+    return this._format;
   }
 
   get id(): string {
@@ -334,26 +340,32 @@ export class Parameter extends Config {
    * @param value number to be converted
    * @returns converted number
    */
-  toFixed(value: number): string {
+  toFixed(value: number, fractionDigits: number = 1): string {
     const valueAsString = value.toString();
-    let fractionDigits = 1;
-    if (valueAsString.includes('.')) {
+    if (valueAsString.includes('.') && fractionDigits > 0) {
       fractionDigits = valueAsString.split('.')[1].length;
     }
     return value.toFixed(fractionDigits);
   }
 
   /**
-   * Write textual code.
+   * Write textual code for Python.
    */
-  toCode(): string {
+  toPythonCode(): string {
     let value: string;
     if (this.isConstant) {
       // Constant value.
-      if (typeof this._value === 'string') {
+      if (this._format === 'integer') {
+        // Integer value
+        value = this.toFixed(this._value as number, 0);
+      } else if (this._format === 'float') {
+        // Float value
+        value = this.toFixed(this._value as number);
+      } else if (typeof this._value === 'string') {
+        // String value
         value = this._value as string;
       } else if (typeof this._value === 'boolean') {
-        // Boolean value for Python.
+        // Boolean value
         value = this._value ? 'True' : 'False';
       } else if (Array.isArray(this._value)) {
         value = JSON.stringify(this._value.map((value: number) => value));


### PR DESCRIPTION
This PR clearifies the value format for parameter in the scripted simulation code in Python

For instance 
- the connection probability has to be strict float (`p=1.0`).
- `indegree` and `outdegree` are integers.