### PR TITLE
Change tag for CI runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ build_app:
     - cat nest_desktop/__init__.py
     - cat .env
   tags:
-    - docker-runner
+    - docker-runner read-only
 
 #
 # BUILD ELECTRON
@@ -65,7 +65,7 @@ build_electron:
     - yarn electron:build
     - cat nest_desktop/__init__.py
   tags:
-    - docker-runner
+    - docker-runner read-only
 
 #
 # DEPLOY PYTHON PACKAGE
@@ -92,7 +92,7 @@ deploy_pypi:
         TWINE_PASSWORD=${PYPI_ACCESS_TOKEN} TWINE_USERNAME=__token__ python -m twine upload dist/*
       fi
   tags:
-    - docker-runner
+    - docker-runner read-only
 
 #
 # DEPLOY DOCKER IMAGE ON EBRAINS
@@ -124,7 +124,7 @@ deploy_ebrains_docker:
   after_script:
     - docker logout docker-registry.ebrains.eu
   tags:
-    - shell-runner
+    - shell-runner read-only
 
 #
 # DEPLOY DOCKER IMAGE ON DOCKER HUB in nestsim organisation
@@ -156,7 +156,7 @@ deploy_docker_hub_nestsim:
   after_script:
     - docker logout
   tags:
-    - shell-runner
+    - shell-runner read-only
 
 #
 # DEPLOY DOCKER IMAGE ON DOCKER HUB in nestdesktop organisation
@@ -188,7 +188,7 @@ deploy_docker_hub_nestdesktop:
   after_script:
     - docker logout
   tags:
-    - shell-runner
+    - shell-runner read-only
 
 #
 # DEPLOY SNAP ON SNAPCRAFT
@@ -211,4 +211,4 @@ deploy_snap:
   after_script:
     - snapcraft logout
   tags:
-    - docker-runner
+    - docker-runner read-only


### PR DESCRIPTION
Since runners are tagged with other names, jobs in CI are stuck. 

The tags of the runners are currently `shell-runner read-only` and `docker-runner read-only`.