### PR TITLE
Sort activities by recorder unit IDs in Insite mode

### DIFF
--- a/src/core/activity/activity.ts
+++ b/src/core/activity/activity.ts
@@ -9,10 +9,10 @@ export class Activity {
   private _events: any = {};
   private _hash: string;
   private _idx: number; // generative
-  private _nodeCollectionId: number;
   private _nodeIds: number[] = [];
   private _nodePositions: number[][] = []; // if spatial
   private _recorder: Node; // parent
+  private _recorderUnitId: number;
   private _state: UnwrapRef<any>;
 
   constructor(recorder: Node, activity: any = {}) {
@@ -74,14 +74,6 @@ export class Activity {
     return this._events.hasOwnProperty('times') ? this._events.times.length : 0;
   }
 
-  get nodeCollectionId(): number {
-    return this._nodeCollectionId;
-  }
-
-  set nodeCollectionId(value: number) {
-    this._nodeCollectionId = value;
-  }
-
   get nodeIds(): number[] {
     return this._nodeIds;
   }
@@ -104,6 +96,14 @@ export class Activity {
 
   get recorder(): Node {
     return this._recorder;
+  }
+
+  get recorderUnitId(): number {
+    return this._recorderUnitId;
+  }
+
+  set recorderUnitId(value: number) {
+    this._recorderUnitId = value;
   }
 
   get state(): UnwrapRef<any> {
@@ -141,7 +141,7 @@ export class Activity {
     this.events = activity.events || { senders: [], times: [] };
     this.nodeIds = activity.nodeIds || [];
     this.nodePositions = activity.nodePositions || [];
-    this.nodeCollectionId = activity.nodeCollectionId;
+    this.recorderUnitId = activity.recorderUnitId || -1;
     this.updateHash();
     this.postInit();
   }

--- a/src/core/activity/analogSignalActivity.ts
+++ b/src/core/activity/analogSignalActivity.ts
@@ -54,7 +54,7 @@ export class AnalogSignalActivity extends Activity {
     }
 
     const attribute: string = 'V_m';
-    const path = `nest/multimeters/${this.nodeCollectionId}/attributes/${attribute}/?fromTime=${this.lastTime}`;
+    const path = `nest/multimeters/${this.recorderUnitId}/attributes/${attribute}/?fromTime=${this.lastTime}`;
     this.project.app.backends.insiteAccess.instance
       .get(path)
       .then((response: any) => {

--- a/src/core/activity/spikeActivity.ts
+++ b/src/core/activity/spikeActivity.ts
@@ -100,9 +100,9 @@ export class SpikeActivity extends Activity {
       return;
     }
 
-    const path = `nest/spikerecorders/${
-      this.nodeCollectionId
-    }/spikes/?fromTime=${this.lastTime + 0.1}`;
+    const path = `nest/spikerecorders/${this.recorderUnitId}/spikes/?fromTime=${
+      this.lastTime + 0.1
+    }`;
     this.project.app.backends.insiteAccess.instance
       .get(path)
       .then((response: any) => {

--- a/src/core/project/insite/insite.ts
+++ b/src/core/project/insite/insite.ts
@@ -202,7 +202,7 @@ export class Insite {
           };
         });
 
-        // Sort activities by recorder unit ids.
+        // Sort activities by recorder unit IDs, as Insite does not provide a sorting at the moment.
         activities.sort(
           (a: any, b: any) => a.recorderUnitId - b.recorderUnitId
         );
@@ -257,7 +257,7 @@ export class Insite {
           };
         });
 
-        // Sort activities by recorder unit ids.
+        // Sort activities by recorder unit IDs, as Insite does not provide a sorting at the moment.
         activities.sort(
           (a: any, b: any) => a.recorderUnitId - b.recorderUnitId
         );

--- a/src/core/project/insite/insite.ts
+++ b/src/core/project/insite/insite.ts
@@ -257,7 +257,7 @@ export class Insite {
           };
         });
 
-        // Sort activities by recorder unit IDs, as Insite does not provide a sorting at the moment.
+        // Sort activities by recorder unit IDs, as Insite does not provide a sorting at the moment. TODO: check in the future
         activities.sort(
           (a: any, b: any) => a.recorderUnitId - b.recorderUnitId
         );

--- a/src/core/project/insite/insite.ts
+++ b/src/core/project/insite/insite.ts
@@ -6,17 +6,17 @@ import { SpikeActivity } from '../../activity/spikeActivity';
 
 type activityType = {
   events: any;
-  nodeCollectionId: number;
   nodeIds: number[];
   nodePositions: number[][];
+  recorderUnitId: number;
 };
 
 type nodeDataType = {
   model: string;
-  nodeCollectionId: number;
   nodeId: number;
   nodeStatus: Object;
   position: Object | null;
+  recorderUnitId: number;
   simulationNodeId: number;
 };
 
@@ -196,11 +196,16 @@ export class Insite {
           }
           return {
             events: { senders: [], times: [] },
-            nodeCollectionId: data.spikerecorderId,
+            recorderUnitId: data.spikerecorderId,
             nodeIds: data.nodeIds,
             nodePositions,
           };
         });
+
+        // Sort activities by recorder unit ids.
+        activities.sort(
+          (a: any, b: any) => a.recorderUnitId - b.recorderUnitId
+        );
 
         // Initialize activities.
         this._project.initActivities(activities);
@@ -246,11 +251,16 @@ export class Insite {
 
           return {
             events,
-            nodeCollectionId: data.multimeterId,
+            recorderUnitId: data.multimeterId,
             nodeIds: data.nodeIds,
             nodePositions,
           };
         });
+
+        // Sort activities by recorder unit ids.
+        activities.sort(
+          (a: any, b: any) => a.recorderUnitId - b.recorderUnitId
+        );
 
         // Initialize activities.
         this._project.initActivities(activities);

--- a/src/core/project/insite/insite.ts
+++ b/src/core/project/insite/insite.ts
@@ -202,7 +202,7 @@ export class Insite {
           };
         });
 
-        // Sort activities by recorder unit IDs, as Insite does not provide a sorting at the moment.
+        // Sort activities by recorder unit IDs, as Insite does not provide a sorting at the moment. TODO: check in the future
         activities.sort(
           (a: any, b: any) => a.recorderUnitId - b.recorderUnitId
         );


### PR DESCRIPTION
This PR fixed color mismatch of activities in Insite mode by sorting activities by recorder unit IDs.

Thus, I renamed `nodeCollectionId` to `recorderUnitId`.

Fixed #367 