### PR TITLE
Fixed param visibility when a copied model is selected

### DIFF
--- a/src/components/node/NodeModelSelect.vue
+++ b/src/components/node/NodeModelSelect.vue
@@ -416,6 +416,8 @@ export default Vue.extend({
      * Update when node model is changed.
      */
     const updateOnModelChange = () => {
+      state.node.hideAllParams();
+      state.node.nodeChanges();
       update();
     };
 


### PR DESCRIPTION
Then a copy model is selected in node panel, it should show no parameters.

Fixed #377 