### PR TITLE
Use iframe to view model documentation

### DIFF
--- a/src/assets/config/ModelView.json
+++ b/src/assets/config/ModelView.json
@@ -1,0 +1,3 @@
+{
+  "getDocFromBackend": false
+}

--- a/src/components/model/ModelDocumentation.vue
+++ b/src/components/model/ModelDocumentation.vue
@@ -59,7 +59,7 @@
     <iframe
       :src="`https://nest-simulator.readthedocs.io/en/latest/models/${
         modelView.state.modelId
-      }.html#models-${parseCebabCase(modelView.state.modelId)}--page-root`"
+      }.html#models-${parseKebabCase(modelView.state.modelId)}--page-root`"
       frameborder="0"
       height="100%"
       v-else
@@ -92,7 +92,7 @@ export default Vue.extend({
       return `https://nest-simulator.readthedocs.io/en/${RTDVersion}/models/${modelView.state.modelId}.html`;
     };
 
-    const parseCebabCase = (text: string) => {
+    const parseKebabCase = (text: string) => {
       return text.replaceAll('_', '-');
     };
 
@@ -109,7 +109,7 @@ export default Vue.extend({
       }
     );
 
-    return { NESTDocURL, modelView, parseCebabCase };
+    return { NESTDocURL, modelView, parseKebabCase };
   },
 });
 </script>

--- a/src/components/model/ModelDocumentation.vue
+++ b/src/components/model/ModelDocumentation.vue
@@ -1,55 +1,70 @@
 <template>
-  <div class="modelDocumentation">
-    <v-toolbar dense flat>
-      <v-toolbar-title>
-        {{ modelView.state.doc.title || modelView.state.modelId }}
-        <v-chip
-          class="mx-4"
+  <div
+    :style="modelView.config.getDocFromBackend ? '{overflow-y: auto}' : '{}'"
+    class="modelDocumentation"
+  >
+    <div v-if="modelView.config.getDocFromBackend">
+      <v-toolbar dense flat>
+        <v-toolbar-title>
+          {{ modelView.state.doc.title || modelView.state.modelId }}
+          <v-chip
+            class="mx-4"
+            outlined
+            small
+            v-if="modelView.state.defaults.element_type"
+            v-text="modelView.state.defaults.element_type"
+          />
+          <v-chip
+            class="mx-4"
+            outlined
+            small
+            v-if="'synapse_model' in modelView.state.defaults"
+            v-text="'synapse'"
+          />
+        </v-toolbar-title>
+        <v-spacer />
+        <v-btn
+          :href="NESTDocURL()"
+          :title="NESTDocURL()"
+          class="mx-1"
           outlined
           small
-          v-if="modelView.state.defaults.element_type"
-          v-text="modelView.state.defaults.element_type"
-        />
-        <v-chip
-          class="mx-4"
-          outlined
-          small
-          v-if="'synapse_model' in modelView.state.defaults"
-          v-text="'synapse'"
-        />
-      </v-toolbar-title>
-      <v-spacer />
-      <v-btn
-        :href="NESTDocURL()"
-        :title="NESTDocURL()"
-        class="mx-1"
-        outlined
-        small
-        target="_blank"
-        text
-      >
-        <v-icon left v-text="'mdi-open-in-new'" />
-        More
-      </v-btn>
-    </v-toolbar>
+          target="_blank"
+          text
+        >
+          <v-icon left v-text="'mdi-open-in-new'" />
+          More
+        </v-btn>
+      </v-toolbar>
 
-    <v-card class="modelDocumentationContent" flat tile>
-      <v-card-subtitle
-        v-if="modelView.state.doc.subtitle"
-        v-text="modelView.state.doc.subtitle"
-      />
-      <v-card
-        :key="block.title"
-        flat
-        tile
-        v-for="block of modelView.state.doc.blocks"
-      >
-        <v-card-title v-text="block.title" />
-        <v-card-text>
-          <pre v-text="block.content" />
-        </v-card-text>
+      <v-card class="modelDocumentationContent" flat tile>
+        <v-card-subtitle
+          v-if="modelView.state.doc.subtitle"
+          v-text="modelView.state.doc.subtitle"
+        />
+        <v-card
+          :key="block.title"
+          flat
+          tile
+          v-for="block of modelView.state.doc.blocks"
+        >
+          <v-card-title v-text="block.title" />
+          <v-card-text>
+            <pre v-text="block.content" />
+          </v-card-text>
+        </v-card>
       </v-card>
-    </v-card>
+    </div>
+
+    <iframe
+      :src="`https://nest-simulator.readthedocs.io/en/latest/models/${
+        modelView.state.modelId
+      }.html#models-${parseCebabCase(modelView.state.modelId)}--page-root`"
+      frameborder="0"
+      height="100%"
+      v-else
+      width="100%"
+    />
   </div>
 </template>
 
@@ -77,6 +92,10 @@ export default Vue.extend({
       return `https://nest-simulator.readthedocs.io/en/${RTDVersion}/models/${modelView.state.modelId}.html`;
     };
 
+    const parseCebabCase = (text: string) => {
+      return text.replaceAll('_', '-');
+    };
+
     onMounted(() => {
       modelView.state.modelId = props.id;
       modelView.updateModelDoc();
@@ -90,7 +109,7 @@ export default Vue.extend({
       }
     );
 
-    return { NESTDocURL, modelView };
+    return { NESTDocURL, modelView, parseCebabCase };
   },
 });
 </script>
@@ -98,6 +117,5 @@ export default Vue.extend({
 <style>
 .modelDocumentation {
   height: calc(100vh - 48px - 24px);
-  overflow-y: auto;
 }
 </style>

--- a/src/components/node/NodeMenu.vue
+++ b/src/components/node/NodeMenu.vue
@@ -115,7 +115,10 @@
         </span>
 
         <span v-if="state.content === 'modelDocumentation'">
-          <ModelDocumentation :id="state.node.modelId" />
+          <ModelDocumentation
+            :id="state.node.modelId"
+            style="overflow-y: hidden; width: 959px"
+          />
         </span>
 
         <span v-if="state.content === 'eventsExport'">

--- a/src/core/model/modelView.ts
+++ b/src/core/model/modelView.ts
@@ -3,11 +3,12 @@ import { reactive, UnwrapRef } from '@vue/composition-api';
 import { consoleLog } from '../common/logger';
 
 import { App } from '../app';
+import { Config } from '../common/config';
 import { Model } from '../model/model';
 import { Node } from '../node/node';
 import { Project } from '../project/project';
 
-export class ModelView {
+export class ModelView extends Config {
   private _app: App;
   // Keywords taken from https://github.com/nest/nest-simulator/blob/master/extras/help_generator/generate_help.py#L73
   private _docKeywords = [
@@ -64,6 +65,7 @@ export class ModelView {
   ];
 
   constructor(app: App) {
+    super('ModelView');
     this._app = app;
     this._state = reactive({
       defaults: {},

--- a/src/views/AppSettings.vue
+++ b/src/views/AppSettings.vue
@@ -112,7 +112,7 @@
                     })
                 "
                 color="accent"
-                label="Get documentation from the backend (plain text)"
+                label="Fetch the documentation from the back-end (plain text) instead of using formatted HTML from ReadTheDocs"
                 v-model="state.modelViewConfig.config.getDocFromBackend"
               />
             </v-card>

--- a/src/views/AppSettings.vue
+++ b/src/views/AppSettings.vue
@@ -104,6 +104,19 @@
           <v-card-title v-text="'Model'" />
           <v-card-text>
             <v-card flat tile>
+              <v-switch
+                @change="
+                  e =>
+                    state.modelViewConfig.updateConfig({
+                      getDocFromBackend: e || false,
+                    })
+                "
+                color="accent"
+                label="Get documentation from the backend (plain text)"
+                v-model="state.modelViewConfig.config.getDocFromBackend"
+              />
+            </v-card>
+            <v-card flat tile>
               <v-card-subtitle v-text="'Accepted recordables'" />
               <span
                 :key="recordable.id"
@@ -227,6 +240,7 @@ export default Vue.extend({
       appConfig: new Config('App'),
       colorSchemes: colorSchemes,
       modelConfig: new Config('Model'),
+      modelViewConfig: new Config('ModelView'),
       networkConfig: new Config('Network'),
       parameterConfig: new Config('Parameter'),
       projectViewConfig: new Config('ProjectView'),


### PR DESCRIPTION
This PR adds iframe for model documentation.

User is able to change the option to get plain text from the backend (in settings).