### PR TITLE
Add button to export networkGraph to image file.

### DIFF
--- a/src/components/network/NetworkEditor.vue
+++ b/src/components/network/NetworkEditor.vue
@@ -96,9 +96,16 @@
       </g>
 
       <rect
-        :fill="$vuetify.theme.dark ? '#121212' : 'white'"
+        :fill="
+          state.graph && state.graph.config.transparentWorkspace
+            ? 'transparent'
+            : $vuetify.theme.dark
+            ? '#121212'
+            : 'white'
+        "
         id="workspaceHandler"
       />
+
       <g id="networkWorkspace">
         <g class="grid no-print" />
         <g v-if="state.graph">
@@ -190,15 +197,15 @@ export default Vue.extend({
     const networkEditor = ref(null);
     const networkGraph = ref(null);
     const state = reactive({
-      network: projectView.state.project.network,
-      graph: undefined,
-      nodeMenu: {
-        node: undefined,
+      connectionMenu: {
+        connection: undefined,
         position: { x: 0, y: 0 },
         show: false,
       },
-      connectionMenu: {
-        connection: undefined,
+      graph: undefined,
+      network: projectView.state.project.network,
+      nodeMenu: {
+        node: undefined,
         position: { x: 0, y: 0 },
         show: false,
       },
@@ -371,7 +378,6 @@ export default Vue.extend({
 .node text {
   font-size: 12px;
   pointer-events: none;
-  text-anchor: middle;
 }
 
 .dragline {

--- a/src/components/network/NetworkEditorToolbar.vue
+++ b/src/components/network/NetworkEditorToolbar.vue
@@ -5,6 +5,7 @@
       absolute
       dense
       flat
+      height="32"
       style="width: 100%; background-color: transparent"
     >
       <div v-if="state.network">
@@ -68,7 +69,48 @@
         </span>
 
         <span>
-          <v-dialog max-width="450" v-model="state.dialog">
+          <v-dialog max-width="450" v-model="state.dialogDownload">
+            <template #activator="{ on, attrs }">
+              <v-btn
+                icon
+                small
+                title="Download network graph"
+                v-bind="attrs"
+                v-on="on"
+              >
+                <v-icon small v-text="'mdi-camera'" />
+              </v-btn>
+            </template>
+
+            <v-card>
+              <v-card-title v-text="'Download network graph as image'" />
+              <v-card-text>
+                <v-checkbox
+                  label="Transparent background"
+                  v-model="state.graph.config.transparentWorkspace"
+                />
+              </v-card-text>
+
+              <v-card-actions>
+                <v-spacer />
+                <v-btn
+                  @click="state.dialogDownload = false"
+                  outlined
+                  small
+                  text
+                  v-text="'close'"
+                />
+                <v-btn
+                  @click="DownloadNetworkGraph"
+                  outlined
+                  small
+                  v-text="'save'"
+                />
+              </v-card-actions>
+            </v-card>
+          </v-dialog>
+
+          <v-dialog max-width="450" v-model="state.dialogDelete">
             <template #activator="{ on, attrs }">
               <v-btn
                 :disabled="state.network.isEmpty"
@@ -81,12 +123,13 @@
                 <v-icon small v-text="'mdi-trash-can-outline'" />
               </v-btn>
             </template>
+
             <v-card>
               <v-card-title v-text="'Are you sure to delete this network?'" />
               <v-card-actions>
                 <v-spacer />
                 <v-btn
-                  @click="state.dialog = false"
+                  @click="state.dialogDelete = false"
                   outlined
                   small
                   text
@@ -174,7 +217,8 @@ export default Vue.extend({
   },
   setup(props) {
     const state = reactive({
-      dialog: false,
+      dialogDelete: false,
+      dialogDownload: false,
       graph: props.graph as NetworkGraph,
       network: props.network as Network,
     });
@@ -184,11 +228,19 @@ export default Vue.extend({
      */
     const deleteNetwork = () => {
       state.network.empty();
-      state.dialog = false;
+      state.dialogDelete = false;
+    };
+
+    /**
+     * Download network graph as svg.
+     */
+    const DownloadNetworkGraph = () => {
+      state.graph.downloadImage();
+      state.dialogDownload = false;
     };
 
     watch(
-      () => [props.graph, props.network],
+      () => [props.graph, props.network, props.transparentWorkspace],
       () => {
         state.graph = props.graph as NetworkGraph;
         state.network = props.network as Network;
@@ -197,6 +249,7 @@ export default Vue.extend({
 
     return {
       deleteNetwork,
+      DownloadNetworkGraph,
       state,
     };
   },

--- a/src/core/network/networkGraph/networkGraph.ts
+++ b/src/core/network/networkGraph/networkGraph.ts
@@ -11,6 +11,7 @@ export class NetworkGraph {
   private _config: any = {
     nodeRadius: 20,
     strokeWidth: 3,
+    transparentWorkspace: true,
   };
   private _connectionGraph: ConnectionGraph;
   private _modelAssignGraph: ModelAssignGraph;
@@ -117,5 +118,49 @@ export class NetworkGraph {
    */
   resize(width: number, height: number): void {
     this._selector.attr('width', width).attr('height', height);
+  }
+
+  /**
+   * Download network graph as svg image.
+   */
+  downloadImage(): void {
+    // Get svg element.
+    var svg = this._selector.node();
+
+    // Get svg source.
+    var serializer = new XMLSerializer();
+    var source = serializer.serializeToString(svg);
+
+    //  Add name spaces.
+    if (!source.match(/^<svg[^>]+xmlns="http\:\/\/www\.w3\.org\/2000\/svg"/)) {
+      source = source.replace(
+        /^<svg/,
+        '<svg xmlns="http://www.w3.org/2000/svg"'
+      );
+    }
+    if (!source.match(/^<svg[^>]+"http\:\/\/www\.w3\.org\/1999\/xlink"/)) {
+      source = source.replace(
+        /^<svg/,
+        '<svg xmlns:xlink="http://www.w3.org/1999/xlink"'
+      );
+    }
+
+    // Add xml declaration.
+    source = '<?xml version="1.0" standalone="no"?>\r\n' + source;
+
+    // Convert svg source to URI data scheme.
+    var url = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(source);
+
+    // Create download link.
+    var downloadLink = document.createElement('a');
+    downloadLink.href = url;
+    downloadLink.download = `nest_desktop-${this._network.project.name}-${this._network.project.app.datetime}.svg`;
+    document.body.appendChild(downloadLink);
+
+    // Apply download.
+    downloadLink.click();
+
+    // Remove download link.
+    document.body.removeChild(downloadLink);
   }
 }

--- a/src/core/node/nodeGraph/nodeGraphShape.ts
+++ b/src/core/node/nodeGraph/nodeGraphShape.ts
@@ -204,6 +204,8 @@ export class NodeGraphShape {
         .select('text')
         .attr('dy', node.isInhibitoryNeuron ? '0.4em' : '0.7em')
         .style('fill', this.darkMode ? 'white' : '#121212')
+        .style('font-family', 'Roboto')
+        .style('text-anchor', 'middle')
         .text(node.view.label);
     });
   }


### PR DESCRIPTION
This PR adds a button in the network editor. 
The user can click on button to save network graph to image file in svg format.