### PR TITLE
Split and disable simulation button

### DIFF
--- a/src/components/simulation/SimulationButton.vue
+++ b/src/components/simulation/SimulationButton.vue
@@ -1,21 +1,26 @@
 <template>
   <div class="simulationButton">
-    <v-menu :close-on-content-click="false" offset-y v-model="state.showMenu">
-      <template #activator="{}">
-        <v-btn
-          :disabled="state.disabled"
-          :loading="state.project.simulation.state.running"
-          @click="state.project.startSimulation()"
-          @contextmenu="showMenu"
-          outlined
-        >
-          <v-icon left>mdi-play</v-icon>
-          <span
-            v-if="state.project.simulation.code.runSimulation"
-            v-text="'Simulate'"
-          />
-          <span v-else v-text="'Prepare'" />
-        </v-btn>
+    <v-menu :close-on-content-click="false" offset-y>
+      <template #activator="{ on }">
+        <div class="split-btn">
+          <v-btn
+            :disabled="state.disabled"
+            :loading="state.project.simulation.state.running"
+            @click="state.project.startSimulation()"
+            class="main-btn"
+            outlined
+          >
+            <v-icon left>mdi-play</v-icon>
+            <span
+              v-if="state.project.simulation.code.runSimulation"
+              v-text="'Simulate'"
+            />
+            <span v-else v-text="'Prepare'" />
+          </v-btn>
+          <v-btn class="actions-btn" outlined v-on="on">
+            <v-icon>mdi-menu-down</v-icon>
+          </v-btn>
+        </div>
       </template>
       <v-list dense>
         <v-list-item
@@ -46,8 +51,8 @@
 import Vue from 'vue';
 import { onMounted, reactive, watch } from '@vue/composition-api';
 
-import core from '@/core';
 import { Project } from '@/core/project/project';
+import core from '@/core';
 
 export default Vue.extend({
   name: 'SimulationButton',
@@ -98,20 +103,8 @@ export default Vue.extend({
         },
       ],
       project: props.project as Project,
-      showMenu: false,
       projectConfig: projectView.config,
     });
-
-    /**
-     * Show simulation context menu.
-     */
-    const showMenu = (e: MouseEvent) => {
-      e.preventDefault();
-      state.showMenu = false;
-      setTimeout(() => {
-        state.showMenu = true;
-      });
-    };
 
     const update = () => {
       state.disabled = props.disabled;
@@ -126,7 +119,24 @@ export default Vue.extend({
       () => update()
     );
 
-    return { showMenu, state };
+    return { state };
   },
 });
 </script>
+
+<style>
+.simulationButton .split-btn {
+  display: inline-block;
+}
+.simulationButton .split-btn .main-btn {
+  border-bottom-right-radius: 0;
+  border-right: none;
+  border-top-right-radius: 0;
+}
+.simulationButton .split-btn .actions-btn {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  min-width: 35px !important;
+  padding: 0 !important;
+}
+</style>

--- a/src/core/common/backend.ts
+++ b/src/core/common/backend.ts
@@ -1,22 +1,19 @@
 import axios from 'axios';
 import combineURLs from 'axios/lib/helpers/combineURLs';
+import { reactive, UnwrapRef } from '@vue/composition-api';
 
 import { Config } from './config';
 
 export class Backend extends Config {
-  private _state: any = {
-    ready: false,
-    version: {},
-    seek: {
-      path: '/',
-      port: 5000,
-      versionPath: '',
-    },
-  };
+  private _state: UnwrapRef<any>;
 
   constructor(name: string, seek = { path: '', port: 5000, versionPath: '' }) {
     super(name);
-    this._state.seek = seek;
+    this._state = reactive({
+      ready: false,
+      seek,
+      version: {},
+    });
   }
 
   get host(): string {

--- a/src/views/Project.vue
+++ b/src/views/Project.vue
@@ -152,7 +152,10 @@
       </v-card>
 
       <div @click="projectView.state.modeIdx = 1">
-        <SimulationButton :project="projectView.state.project" />
+        <SimulationButton
+          :disabled="!nestSimulatorState.ready"
+          :project="projectView.state.project"
+        />
       </div>
     </v-app-bar>
 
@@ -449,6 +452,7 @@ export default Vue.extend({
 
     return {
       appConfig: core.app.config,
+      nestSimulatorState: core.app.backends.nestSimulator.state,
       projectView,
       resizeSidebar,
       state,


### PR DESCRIPTION
This PR splits simulation button which also shows dropdown menu for simulation configurations.

Furthermore the simulation button is disabled when the nest server is not found.