### PR TITLE
Add menu popover for panel model in activity chart

### DIFF
--- a/src/components/activity/activityChart/ActivityChartController.vue
+++ b/src/components/activity/activityChart/ActivityChartController.vue
@@ -31,31 +31,10 @@
             Add panel
           </v-btn>
         </template>
-        <v-list dense>
-          <v-subheader style="height: 28px" v-text="'Analog signals'" />
-          <v-list-item
-            :disabled="
-              !state.graph.project.state.activities.hasSomeAnalogRecorders
-            "
-            :key="'analogPanel' + index"
-            @click="addPanel(model.id)"
-            v-for="(model, index) in state.graph.panel.modelsAnalog"
-          >
-            <v-icon left small v-text="model.icon" />
-            <v-list-item-title v-text="model.label" />
-          </v-list-item>
-
-          <v-subheader style="height: 28px" v-text="'Spikes'" />
-          <v-list-item
-            :disabled="!state.graph.project.state.activities.hasSomeSpikeRecorders"
-            :key="'spikePanel' + index"
-            @click="addPanel(model.id)"
-            v-for="(model, index) in state.graph.panel.modelsSpike"
-          >
-            <v-icon class="mr-2" small v-text="model.icon" />
-            <v-list-item-title v-text="model.label" />
-          </v-list-item>
-        </v-list>
+        <ActivityChartPanelMenuPopover
+          :graph="state.graph"
+          @changed="addPanel"
+        />
       </v-menu>
     </v-toolbar>
 
@@ -181,6 +160,7 @@ import draggable from 'vuedraggable';
 
 import { ActivityChartGraph } from '@/core/activity/activityChart/activityChartGraph';
 import { NodeRecord } from '@/core/node/nodeRecord';
+import ActivityChartPanelMenuPopover from '@/components/activity/activityChart/ActivityChartPanelMenuPopover.vue';
 import ActivityChartPanelToolbar from '@/components/activity/activityChart/ActivityChartPanelToolbar.vue';
 import core from '@/core';
 import ParameterEdit from '@/components/parameter/ParameterEdit.vue';
@@ -188,6 +168,7 @@ import ParameterEdit from '@/components/parameter/ParameterEdit.vue';
 export default Vue.extend({
   name: 'ActivityChartController',
   components: {
+    ActivityChartPanelMenuPopover,
     ActivityChartPanelToolbar,
     draggable,
     ParameterEdit,

--- a/src/components/activity/activityChart/ActivityChartPanelMenuPopover.vue
+++ b/src/components/activity/activityChart/ActivityChartPanelMenuPopover.vue
@@ -1,0 +1,81 @@
+<template>
+  <div class="activityChartPanelMenuPopover" v-if="state.graph">
+    <v-card>
+      <v-list
+        dense
+        v-show="state.graph.project.state.activities.hasSomeAnalogRecorders"
+      >
+        <v-subheader style="height: 28px" v-text="'Analog signals'" />
+        <v-list-item
+          :key="'analogPanel' + index"
+          @click="selectModel(model.id)"
+          v-for="(model, index) in state.graph.modelsAnalog"
+        >
+          <v-icon left small v-text="model.icon" />
+          <v-list-item-title v-text="model.label" />
+        </v-list-item>
+      </v-list>
+
+      <v-list
+        dense
+        v-show="state.graph.project.state.activities.hasSomeSpikeRecorders"
+      >
+        <v-subheader style="height: 28px" v-text="'Spike activity'" />
+        <v-list-item
+          :key="'spikePanel' + index"
+          @click="selectModel(model.id)"
+          v-for="(model, index) in state.graph.modelsSpike"
+        >
+          <v-icon left small v-text="model.icon" />
+          <v-list-item-title v-text="model.label" />
+        </v-list-item>
+      </v-list>
+    </v-card>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { reactive, watch } from '@vue/composition-api';
+import { ActivityChartGraph } from '@/core/activity/activityChart/activityChartGraph';
+export default Vue.extend({
+  name: 'activityChartPanelMenuPopover',
+  props: {
+    graph: ActivityChartGraph,
+  },
+  setup(props, { emit }) {
+    const state = reactive({
+      graph: props.graph as ActivityChartGraph | undefined,
+    });
+
+    /**
+     * Select panel model.
+     */
+    const selectModel = (modelId: string) => {
+      emit('changed', modelId);
+    };
+
+    watch(
+      () => props.graph,
+      () => {
+        state.graph = props.graph as ActivityChartGraph;
+      }
+    );
+
+    return { selectModel, state };
+  },
+});
+</script>
+
+<style>
+.activityChartPanelToolbar .icons {
+  display: none;
+  line-height: 36px;
+  position: absolute;
+  right: 4px;
+  top: 0;
+}
+.activityChartPanelToolbar:hover .icons {
+  display: block;
+}
+</style>

--- a/src/components/activity/activityChart/ActivityChartPanelToolbar.vue
+++ b/src/components/activity/activityChart/ActivityChartPanelToolbar.vue
@@ -52,33 +52,10 @@
           />
         </span>
       </template>
-      <v-list dense>
-        <v-subheader style="height: 28px" v-text="'Analog signals'" />
-        <v-list-item
-          :disabled="
-            !state.panel.graph.project.state.activities.hasSomeAnalogEvents
-          "
-          :key="'analogPanel' + index"
-          @click="selectModel(model.id)"
-          v-for="(model, index) in state.panel.modelsAnalog"
-        >
-          <v-icon left small v-text="model.icon" />
-          <v-list-item-title v-text="model.label" />
-        </v-list-item>
-
-        <v-subheader style="height: 28px" v-text="'Spikes'" />
-        <v-list-item
-          :disabled="
-            !state.panel.graph.project.state.activities.hasSomeSpikeEvents
-          "
-          :key="'spikePanel' + index"
-          @click="selectModel(model.id)"
-          v-for="(model, index) in state.panel.modelsSpike"
-        >
-          <v-icon left small v-text="model.icon" />
-          <v-list-item-title v-text="model.label" />
-        </v-list-item>
-      </v-list>
+      <ActivityChartPanelMenuPopover
+        :graph="state.panel.graph"
+        @changed="selectModel"
+      />
     </v-menu>
   </div>
 </template>
@@ -89,9 +66,13 @@ import { onMounted, reactive, watch } from '@vue/composition-api';
 
 import { ActivityChartPanel } from '@/core/activity/activityChart/activityChartPanel';
 import core from '@/core';
+import ActivityChartPanelMenuPopover from '@/components/activity/activityChart/ActivityChartPanelMenuPopover.vue';
 
 export default Vue.extend({
   name: 'ActivityChartPanelToolbar',
+  components: {
+    ActivityChartPanelMenuPopover,
+  },
   props: {
     panel: ActivityChartPanel,
   },

--- a/src/core/activity/activityChart/activityChartGraph.ts
+++ b/src/core/activity/activityChart/activityChartGraph.ts
@@ -1,13 +1,88 @@
 import * as Plotly from 'plotly.js-dist-min';
 
 import { ActivityChartPanel } from './activityChartPanel';
+import { ActivityChartPanelModel } from './activityChartPanelModel';
 import { Project } from '../../project/project';
+import { AnalogSignalHistogramModel } from './activityChartPanelModels/analogSignalHistogramModel';
+import { AnalogSignalPlotModel } from './activityChartPanelModels/analogSignalPlotModel';
+import { CVISIHistogramModel } from './activityChartPanelModels/CVISIHistogramModel';
+import { InterSpikeIntervalHistogramModel } from './activityChartPanelModels/interSpikeIntervalHistogramModel';
+import { SenderCVISIPlotModel } from './activityChartPanelModels/senderCVISIPlotModel';
+import { SenderMeanISIPlotModel } from './activityChartPanelModels/senderMeanISIPlotModel';
+import { SenderSpikeCountPlotModel } from './activityChartPanelModels/senderSpikeCountPlotModel';
+import { SpikeTimesHistogramModel } from './activityChartPanelModels/spikeTimesHistogramModel';
+import { SpikeTimesRasterPlotModel } from './activityChartPanelModels/spikeTimesRasterPlotModel';
 
 export class ActivityChartGraph {
   private _config: any = {};
   private _data: any[] = [];
   private _imageButtonOptions: any;
   private _layout: any = {};
+  private _models: any[] = [
+    {
+      activityType: 'analog',
+      component: AnalogSignalPlotModel,
+      id: 'analogSignalPlot',
+      icon: 'mdi-chart-bell-curve-cumulative',
+      label: 'Analog signals',
+    },
+    {
+      activityType: 'analog',
+      component: AnalogSignalHistogramModel,
+      id: 'analogSignalHistogram',
+      icon: 'mdi-chart-bar',
+      label: 'analog signals',
+    },
+    {
+      activityType: 'spike',
+      component: SpikeTimesRasterPlotModel,
+      id: 'spikeTimesRasterPlot',
+      icon: 'mdi-chart-scatter-plot',
+      label: 'Spike times',
+    },
+    {
+      activityType: 'spike',
+      component: SpikeTimesHistogramModel,
+      id: 'spikeTimesHistogram',
+      icon: 'mdi-chart-bar',
+      label: 'Spike times',
+    },
+    {
+      activityType: 'spike',
+      component: InterSpikeIntervalHistogramModel,
+      id: 'interSpikeIntervalHistogram',
+      icon: 'mdi-chart-bar',
+      label: 'Inter-spike interval',
+    },
+    {
+      activityType: 'spike',
+      component: CVISIHistogramModel,
+      id: 'CVISIHistogram',
+      icon: 'mdi-chart-bar',
+      label: 'CV of ISI',
+    },
+    {
+      activityType: 'spike',
+      component: SenderSpikeCountPlotModel,
+      id: 'senderSpikeCountPlot',
+      icon: 'mdi-chart-bell-curve-cumulative',
+      label: 'Spike count in each sender',
+    },
+    {
+      activityType: 'spike',
+      component: SenderMeanISIPlotModel,
+      id: 'senderMeanISIPlot',
+      icon: 'mdi-chart-bell-curve-cumulative',
+      label: 'Mean ISI in each sender',
+    },
+    {
+      activityType: 'spike',
+      component: SenderCVISIPlotModel,
+      id: 'senderCVISIPlot',
+      icon: 'mdi-chart-bell-curve-cumulative',
+      label: 'CV ISI in each sender',
+    },
+  ];
   private _options: any = {};
   private _panel: ActivityChartPanel;
   private _panels: ActivityChartPanel[] = [];
@@ -90,6 +165,23 @@ export class ActivityChartGraph {
 
   get layout(): any {
     return this._layout;
+  }
+
+  get models(): ActivityChartPanelModel[] {
+    return this._models;
+  }
+
+  get modelsAnalog(): ActivityChartPanelModel[] {
+    return this._models.filter(
+      (model: ActivityChartPanelModel) => model.activityType === 'analog'
+    );
+  }
+
+  get modelsSpike(): ActivityChartPanelModel[] {
+    return this._models.filter(
+      (model: ActivityChartPanelModel) =>
+        model.activityType === 'spike' && model['source'] != 'elephant'
+    );
   }
 
   get options(): any {

--- a/src/core/activity/activityChart/activityChartPanel.ts
+++ b/src/core/activity/activityChart/activityChartPanel.ts
@@ -3,14 +3,6 @@ import * as math from 'mathjs';
 import { ActivityChartPanelModel } from './activityChartPanelModel';
 import { ActivityChartGraph } from './activityChartGraph';
 
-import { AnalogSignalHistogramModel } from './activityChartPanelModels/analogSignalHistogramModel';
-import { AnalogSignalPlotModel } from './activityChartPanelModels/analogSignalPlotModel';
-import { CVISIHistogramModel } from './activityChartPanelModels/CVISIHistogramModel';
-import { InterSpikeIntervalHistogramModel } from './activityChartPanelModels/interSpikeIntervalHistogramModel';
-import { SenderCVISIPlotModel } from './activityChartPanelModels/senderCVISIPlotModel';
-import { SenderMeanISIPlotModel } from './activityChartPanelModels/senderMeanISIPlotModel';
-import { SenderSpikeCountPlotModel } from './activityChartPanelModels/senderSpikeCountPlotModel';
-import { SpikeTimesHistogramModel } from './activityChartPanelModels/spikeTimesHistogramModel';
 import { SpikeTimesRasterPlotModel } from './activityChartPanelModels/spikeTimesRasterPlotModel';
 
 export class ActivityChartPanel {
@@ -28,71 +20,6 @@ export class ActivityChartPanel {
       title: '',
     },
   };
-  private _models: any[] = [
-    {
-      activityType: 'analog',
-      component: AnalogSignalPlotModel,
-      id: 'analogSignalPlot',
-      icon: 'mdi-chart-bell-curve-cumulative',
-      label: 'Analog signals',
-    },
-    {
-      activityType: 'analog',
-      component: AnalogSignalHistogramModel,
-      id: 'analogSignalHistogram',
-      icon: 'mdi-chart-bar',
-      label: 'analog signals',
-    },
-    {
-      activityType: 'spike',
-      component: SpikeTimesRasterPlotModel,
-      id: 'spikeTimesRasterPlot',
-      icon: 'mdi-chart-scatter-plot',
-      label: 'Spike times',
-    },
-    {
-      activityType: 'spike',
-      component: SpikeTimesHistogramModel,
-      id: 'spikeTimesHistogram',
-      icon: 'mdi-chart-bar',
-      label: 'Spike times',
-    },
-    {
-      activityType: 'spike',
-      component: InterSpikeIntervalHistogramModel,
-      id: 'interSpikeIntervalHistogram',
-      icon: 'mdi-chart-bar',
-      label: 'Inter-spike interval',
-    },
-    {
-      activityType: 'spike',
-      component: CVISIHistogramModel,
-      id: 'CVISIHistogram',
-      icon: 'mdi-chart-bar',
-      label: 'CV of ISI',
-    },
-    {
-      activityType: 'spike',
-      component: SenderSpikeCountPlotModel,
-      id: 'senderSpikeCountPlot',
-      icon: 'mdi-chart-bell-curve-cumulative',
-      label: 'Spike count in each sender',
-    },
-    {
-      activityType: 'spike',
-      component: SenderMeanISIPlotModel,
-      id: 'senderMeanISIPlot',
-      icon: 'mdi-chart-bell-curve-cumulative',
-      label: 'Mean ISI in each sender',
-    },
-    {
-      activityType: 'spike',
-      component: SenderCVISIPlotModel,
-      id: 'senderCVISIPlot',
-      icon: 'mdi-chart-bell-curve-cumulative',
-      label: 'CV ISI in each sender',
-    },
-  ];
   private _model: ActivityChartPanelModel;
   private _state = {
     initialized: false,
@@ -130,22 +57,6 @@ export class ActivityChartPanel {
 
   get model(): ActivityChartPanelModel {
     return this._model;
-  }
-
-  get models(): ActivityChartPanelModel[] {
-    return this._models;
-  }
-
-  get modelsAnalog(): ActivityChartPanelModel[] {
-    return this._models.filter(
-      (model: ActivityChartPanelModel) => model.activityType === 'analog'
-    );
-  }
-
-  get modelsSpike(): ActivityChartPanelModel[] {
-    return this._models.filter(
-      (model: ActivityChartPanelModel) => model.activityType === 'spike'
-    );
   }
 
   get params(): any[] {
@@ -198,7 +109,7 @@ export class ActivityChartPanel {
     modelSpec: any = {}
   ): void {
     if (modelId) {
-      const model: any = this._models.find(
+      const model: any = this._graph.models.find(
         (model: any) => model.id === modelId
       );
       if (model) {


### PR DESCRIPTION
This PR fixes disable state of items to select panel model. 

In this fixing, the menu popover is implemented for showing list of panel models.