### PR TITLE
Fix gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
 
 build_app:
   stage: build
-  image: node:lts-alpine
+  image: node:16-alpine
   artifacts:
     paths:
       - .env
@@ -20,12 +20,13 @@ build_app:
     - when: always
   before_script:
     - touch .env
-    - VERSION="$(node -p "require('./package.json').version")"
     - |-
       if [[ $CI_COMMIT_BRANCH == "main" ]]; then
+        VERSION="$(node -p "require('./package.json').version")"
         echo "__version__ = '${VERSION}'" >> nest_desktop/__init__.py
         echo "DOCKER_TAG='${VERSION}'" >> .env
       else
+        VERSION="$(node -p "var sem = {alpha: 'a', beta: 'b', dev: 'dev', rc: 'rc'}; var v = require('./package.json').version.split('-'); [v[0], sem[v[1]]].join('')")"
         echo "__version__ = '${VERSION}${CI_PIPELINE_IID}'" >> nest_desktop/__init__.py
         echo "DOCKER_TAG='${VERSION}${CI_PIPELINE_IID}'" >> .env
       fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,15 +20,15 @@ build_app:
     - when: always
   before_script:
     - touch .env
+    - VERSION="$(node -p "require('./package.json').version")"
     - |-
       if [[ $CI_COMMIT_BRANCH == "main" ]]; then
-        VERSION="$(node -p "require('./package.json').version")"
         echo "__version__ = '${VERSION}'" >> nest_desktop/__init__.py
         echo "DOCKER_TAG='${VERSION}'" >> .env
       else
-        VERSION="$(node -p "var sem = {alpha: 'a', beta: 'b', dev: 'dev', rc: 'rc'}; var v = require('./package.json').version.split('-'); [v[0], sem[v[1]]].join('')")"
-        echo "__version__ = '${VERSION}${CI_PIPELINE_IID}'" >> nest_desktop/__init__.py
-        echo "DOCKER_TAG='${VERSION}${CI_PIPELINE_IID}'" >> .env
+        PYTHON_VERSION="$(node -p "var v = require('./package.json').version.split('-'); [v[0], {alpha: 'a', beta: 'b', dev: 'dev', rc: 'rc'}[v[1]]].join('')")"
+        echo "__version__ = '${PYTHON_VERSION}${CI_PIPELINE_IID}'" >> nest_desktop/__init__.py
+        echo "DOCKER_TAG='${VERSION}.${CI_PIPELINE_IID}'" >> .env
       fi
     - yarn install
   script:
@@ -55,11 +55,12 @@ build_electron:
       when: never
     - when: always
   before_script:
-    - VERSION="$(node -p "require('./package.json').version")"
     - |-
       if [[ $CI_COMMIT_BRANCH == "main" ]]; then
+        VERSION="$(node -p "require('./package.json').version")"
         echo "__version__ = '${VERSION}'" >> nest_desktop/__init__.py
       else
+        VERSION="$(node -p "var v = require('./package.json').version.split('-'); [v[0], {alpha: 'a', beta: 'b', dev: 'dev', rc: 'rc'}[v[1]]].join('')")"
         echo "__version__ = '${VERSION}${CI_PIPELINE_IID}'" >> nest_desktop/__init__.py
       fi
     - yarn

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-desktop",
-  "version": "3.2.0b",
+  "version": "3.2.0-beta",
   "private": false,
   "description": "NEST Desktop is a web-based application which provides a graphical user interface for NEST Simulator.",
   "author": {


### PR DESCRIPTION
Since few weeks node 18 is the new LTS and thus causes issues in building app in gitlab CI.
We keep using node 16 but in future we will upgrade to node 18.

Additonally, I added configuration that rewrite version for Python Package.
The official semantics of npm is like `3.2.0-beta` whereas in PyPI only accepts `3.2.0b`.