### PR TITLE
Improve/fix descriptions

### DIFF
--- a/src/components/dialog/ModelsDialog.vue
+++ b/src/components/dialog/ModelsDialog.vue
@@ -72,9 +72,7 @@
             appState.dialog.action.slice(1)
           }}
         </v-card-title>
-        <v-card-subtitle
-          v-text="`Select projects to ${appState.dialog.action}`"
-        >
+        <v-card-subtitle v-text="`Select models to ${appState.dialog.action}`">
         </v-card-subtitle>
 
         <v-card-text>

--- a/src/components/dialog/ModelsDialog.vue
+++ b/src/components/dialog/ModelsDialog.vue
@@ -82,7 +82,7 @@
                 <tr>
                   <th v-text="'Model name'" />
                   <th v-text="'Element type'" />
-                  <th class="text-center" v-text="'Selected'" />
+                  <th class="text-center" v-text="'Export'" />
                 </tr>
               </thead>
               <tbody>

--- a/src/components/dialog/ProjectsDialog.vue
+++ b/src/components/dialog/ProjectsDialog.vue
@@ -79,9 +79,9 @@
                   <th v-text="'Updated at'" />
                   <th
                     class="text-center"
+                    title="Validation is required to export a project"
                     v-if="dialogState.action === 'export'"
                     v-text="'Validate ⓘ'"
-                    title="Validation is required to export a project"
                   />
                   <th class="text-center" v-text="'Export'" />
                   <th

--- a/src/components/dialog/ProjectsDialog.vue
+++ b/src/components/dialog/ProjectsDialog.vue
@@ -80,13 +80,14 @@
                   <th
                     class="text-center"
                     v-if="dialogState.action === 'export'"
-                    v-text="'Validate'"
+                    v-text="'Validate ⓘ'"
+                    title="Validation is required to export a project"
                   />
-                  <th class="text-center" v-text="'Selected'" />
+                  <th class="text-center" v-text="'Export'" />
                   <th
                     class="text-center"
                     v-if="dialogState.action === 'export'"
-                    v-text="'Activities'"
+                    v-text="'Include activities'"
                   />
                 </tr>
               </thead>

--- a/src/components/navigation/ModelNavList.vue
+++ b/src/components/navigation/ModelNavList.vue
@@ -110,7 +110,7 @@
             v-text="
               state.models.length +
               ' model' +
-              (state.models.length > 1 ? 's' : '')
+              (state.models.length != 1 ? 's' : '')
             "
           />
           <v-virtual-scroll

--- a/src/components/navigation/ProjectNavList.vue
+++ b/src/components/navigation/ProjectNavList.vue
@@ -61,7 +61,7 @@
             v-text="
               projectStore.filteredProjects.length +
               ' project' +
-              (projectStore.filteredProjects.length > 1 ? 's' : '')
+              (projectStore.filteredProjects.length != 1 ? 's' : '')
             "
           />
           <v-virtual-scroll

--- a/src/components/network/NetworkEditorToolbar.vue
+++ b/src/components/network/NetworkEditorToolbar.vue
@@ -130,7 +130,7 @@
                 v-text="'Are you sure to delete all elements of this network?'"
               />
               <v-card-actions>
-                this network-spacer />
+                <v-spacer />
                 <v-btn
                   @click="state.dialogDelete = false"
                   outlined

--- a/src/components/network/NetworkEditorToolbar.vue
+++ b/src/components/network/NetworkEditorToolbar.vue
@@ -74,7 +74,7 @@
               <v-btn
                 icon
                 small
-                title="Download network graph"
+                title="Export network graph"
                 v-bind="attrs"
                 v-on="on"
               >
@@ -83,7 +83,8 @@
             </template>
 
             <v-card>
-              <v-card-title v-text="'Download network graph as image'" />
+              <v-card-title v-text="'Export network graph'" />
+              <v-card-subtitle v-text="'Please select the export options'" />
               <v-card-text>
                 <v-checkbox
                   label="Transparent background"
@@ -116,7 +117,7 @@
                 :disabled="state.network.isEmpty"
                 icon
                 small
-                title="Delete network"
+                title="Delete all network elements"
                 v-bind="attrs"
                 v-on="on"
               >
@@ -125,9 +126,11 @@
             </template>
 
             <v-card>
-              <v-card-title v-text="'Are you sure to delete this network?'" />
+              <v-card-title
+                v-text="'Are you sure to delete all elements of this network?'"
+              />
               <v-card-actions>
-                <v-spacer />
+                this network-spacer />
                 <v-btn
                   @click="state.dialogDelete = false"
                   outlined
@@ -152,7 +155,7 @@
             @click="() => state.graph.workspace.toggleCenterSelected()"
             icon
             small
-            title="Auto-centering selected"
+            title="Auto-center currently selected element"
           >
             <v-icon
               small
@@ -171,7 +174,7 @@
             @click="() => state.graph.workspace.toggleCenterNetwork()"
             icon
             small
-            title="Auto-centering network graph"
+            title="Auto-center whole network graph"
           >
             <v-icon small v-text="'mdi-focus-field'" />
           </v-btn>
@@ -181,7 +184,7 @@
             @click="() => state.graph.workspace.toggleGrid()"
             icon
             small
-            title="Show grid"
+            title="Show background grid"
           >
             <v-icon
               small


### PR DESCRIPTION
This PR improves/fixes some descriptions. The descriptions in the project export dialog have still some room for improvements. With the new help text (title), it should be a bit more obvious that the "validate" checkbox need to be marked in order to export a project. However, the "i" icon should normally be clicked instead of hovered. Therefore, I consider these changes more as a first fix. In the long term, it might be a good idea to merge the "validate" and "export" columns?