### PR TITLE
Increase memory limit of dev server

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,7 +1,5 @@
 process.env.VUE_APP_VERSION = require('./package.json').version;
-
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-const { NewLineKind } = require('typescript');
 
 
 module.exports = {
@@ -9,7 +7,7 @@ module.exports = {
   outputDir: './nest_desktop/app',
   transpileDependencies: ['vuetify'],
   productionSourceMap: false,
-  parallel: false,
+  parallel: true,
 
   // https://stackoverflow.com/questions/55258355/vue-clis-type-checking-service-ignores-memory-limits#55810460
   // and https://cli.vuejs.org/config/#parallel
@@ -28,11 +26,10 @@ module.exports = {
     // copy the options from the original ones, but modify memory and CPUs
     const newForkTsCheckerOptions = existingForkTsChecker.options;
     newForkTsCheckerOptions.memoryLimit = 8192;
-    newForkTsCheckerOptions.workers = 2;//require('os').cpus().length - 1;
+    newForkTsCheckerOptions.workers = 4; //require('os').cpus().length;
     config.plugins.push(
       new ForkTsCheckerWebpackPlugin(newForkTsCheckerOptions)
     );
-    console.log(config.module);
     config.module.rules.push({
       test: /\.code/i,
       use: 'raw-loader',

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,19 +1,43 @@
 process.env.VUE_APP_VERSION = require('./package.json').version;
 
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const { NewLineKind } = require('typescript');
+
+
 module.exports = {
   publicPath: process.env.BASE_URL, // '.',
   outputDir: './nest_desktop/app',
   transpileDependencies: ['vuetify'],
   productionSourceMap: false,
-  configureWebpack: {
-    module: {
-      rules: [
-        {
-          test: /\.code/i,
-          use: 'raw-loader',
-        },
-      ],
-    },
+  parallel: false,
+
+  // https://stackoverflow.com/questions/55258355/vue-clis-type-checking-service-ignores-memory-limits#55810460
+  // and https://cli.vuejs.org/config/#parallel
+  configureWebpack: config => {
+    // save the current ForkTsCheckerWebpackPlugin
+    const existingForkTsChecker = config.plugins.filter(
+      plugin => plugin instanceof ForkTsCheckerWebpackPlugin
+    )[0];
+
+    // remove it
+    config.plugins = config.plugins.filter(
+      plugin => !(plugin instanceof ForkTsCheckerWebpackPlugin)
+    );
+    
+
+    // copy the options from the original ones, but modify memory and CPUs
+    const newForkTsCheckerOptions = existingForkTsChecker.options;
+    newForkTsCheckerOptions.memoryLimit = 8192;
+    newForkTsCheckerOptions.workers = 2;//require('os').cpus().length - 1;
+    config.plugins.push(
+      new ForkTsCheckerWebpackPlugin(newForkTsCheckerOptions)
+    );
+    console.log(config.module);
+    config.module.rules.push({
+      test: /\.code/i,
+      use: 'raw-loader',
+    });
+    console.log(config.module);
   },
   chainWebpack: config => {
     config.plugin('html').tap(args => {

--- a/vue.config.js
+++ b/vue.config.js
@@ -30,11 +30,12 @@ module.exports = {
     config.plugins.push(
       new ForkTsCheckerWebpackPlugin(newForkTsCheckerOptions)
     );
+
+    // add code files to rules
     config.module.rules.push({
       test: /\.code/i,
       use: 'raw-loader',
     });
-    console.log(config.module);
   },
   chainWebpack: config => {
     config.plugin('html').tap(args => {


### PR DESCRIPTION
This PR increases the memory limit of the development server. The number of workers stays at 4, since that number seems to make no big difference for the compile time. It might be that the single-threaded tasks already take the main time.