### PR TITLE
Fix redirecting error when nav list is empty

### DIFF
--- a/src/core/model/modelStore.ts
+++ b/src/core/model/modelStore.ts
@@ -221,7 +221,7 @@ export class ModelStore {
   }
 
   get recentModelId(): string {
-    return this._state.models[0].id || undefined;
+    return this._state.models.length > 0 ? this._state.models[0].id : undefined;
   }
 
   /**

--- a/src/core/model/modelView.ts
+++ b/src/core/model/modelView.ts
@@ -407,10 +407,14 @@ export class ModelView extends Config {
       modelId = this._app.model.recentModelId;
     }
 
-    // Check if the page is already loaded to avoid "Avoided redundant
-    // navigation" error.
     const router: VueRouter = this._app.vueSetupContext.root.$router;
-    if (router.currentRoute.params.id !== modelId) {
+    if (modelId == undefined) {
+      router.push({
+        name: 'model',
+      });
+    } else if (router.currentRoute.params.id !== modelId) {
+      // Check if the page is already loaded to avoid "Avoided redundant
+      // navigation" error.
       router.push({
         name: 'modelId',
         params: { id: modelId },

--- a/src/core/project/projectStore.ts
+++ b/src/core/project/projectStore.ts
@@ -52,7 +52,9 @@ export class ProjectStore {
   }
 
   get recentProjectId(): string {
-    return this._state.projects[0].id || undefined;
+    return this._state.projects.length > 0
+      ? this._state.projects[0].id
+      : undefined;
   }
 
   get state(): UnwrapRef<any> {

--- a/src/core/project/projectView.ts
+++ b/src/core/project/projectView.ts
@@ -250,17 +250,16 @@ export class ProjectView extends Config {
    */
   redirect(projectId: string = ''): void {
     if (projectId == undefined || projectId.length === 0) {
-      if (
+      // Get stated project ID when it is not defined.
+      projectId =
         this._state.projectId != null &&
         this._app.project.state.projects.find(
           (project: Project) => project.id === this._state.projectId
         )
-      ) {
-        projectId = this._state.projectId;
-      } else {
-        projectId = this._app.project.recentProjectId;
-      }
+          ? this._state.projectId
+          : this._app.project.recentProjectId;
     } else if (
+      // Get recent project ID when defined project ID is not found.
       !this._app.project.state.projects.find(
         (project: Project) => project.id === projectId
       )
@@ -268,10 +267,14 @@ export class ProjectView extends Config {
       projectId = this._app.project.recentProjectId;
     }
 
-    // Check if the page is already loaded to avoid "Avoided redundant
-    // navigation" error.
     const router: VueRouter = this._app.vueSetupContext.root.$router;
-    if (router.currentRoute.params.id !== projectId) {
+    if (projectId == undefined) {
+      router.push({
+        name: 'project',
+      });
+    } else if (router.currentRoute.params.id !== projectId) {
+      // Check if the page is already loaded to avoid "Avoided redundant
+      // navigation" error.
       router.push({
         name: 'projectId',
         params: { id: projectId },

--- a/src/core/project/projectView.ts
+++ b/src/core/project/projectView.ts
@@ -268,11 +268,7 @@ export class ProjectView extends Config {
     }
 
     const router: VueRouter = this._app.vueSetupContext.root.$router;
-    if (projectId == undefined) {
-      router.push({
-        name: 'project',
-      });
-    } else if (router.currentRoute.params.id !== projectId) {
+    if (router.currentRoute.params.id !== projectId) {
       // Check if the page is already loaded to avoid "Avoided redundant
       // navigation" error.
       router.push({


### PR DESCRIPTION
This PR fixes routing issue on empty navigation list.

When user deletes all projects or all models, the router redirecting doesn't work.

Closes #459 