### PR TITLE
Fix url to error messages

### DIFF
--- a/src/core/simulation/simulation.ts
+++ b/src/core/simulation/simulation.ts
@@ -99,7 +99,7 @@ export class Simulation extends Config {
       stateToast.message += ' -- Click for details...';
       stateToast.onClick = () =>
         window.open(
-          'https://nest-desktop.readthedocs.io/en/latest/user/troubleshooting.html#error-messages',
+          'https://nest-desktop.readthedocs.io/en/latest/troubleshootings/index.html#error-messages',
           '_blank'
         );
     }


### PR DESCRIPTION
This PR fixes link to error messages page on user documentation.

The doc is not in the latest tag but after release.