### PR TITLE
Add "Select all"/"Unselect all" buttons to model/project export and delete views

### DIFF
--- a/src/components/dialog/ModelsDialog.vue
+++ b/src/components/dialog/ModelsDialog.vue
@@ -76,7 +76,7 @@
         </v-card-subtitle>
 
         <v-card-text>
-          <v-simple-table v-if="appState.dialog.data.models.length !== 0">
+          <v-simple-table>
             <template #default>
               <thead>
                 <tr>
@@ -85,7 +85,7 @@
                   <th class="text-center" v-text="'Export'" />
                 </tr>
               </thead>
-              <tbody>
+              <tbody v-if="appState.dialog.data.models.length > 0">
                 <tr
                   :key="index"
                   v-for="(model, index) in appState.dialog.data.models"
@@ -102,6 +102,9 @@
                   </td>
                 </tr>
               </tbody>
+              <tbody v-else>
+                No files saved in this browser session were found.
+              </tbody>
             </template>
           </v-simple-table>
         </v-card-text>
@@ -116,7 +119,23 @@
             v-text="'cancel'"
           />
           <v-btn
-            :disabled="!appState.dialog.data.models.some(p => p.state.selected)"
+            :disabled="appState.dialog.data.models.every(m => m.state.selected)"
+            @click="selectAll"
+            outlined
+            small
+            text
+            v-text="'select all'"
+          />
+          <v-btn
+            :disabled="!appState.dialog.data.models.some(m => m.state.selected)"
+            @click="unselectAll"
+            outlined
+            small
+            text
+            v-text="'unselect all'"
+          />
+          <v-btn
+            :disabled="!appState.dialog.data.models.some(m => m.state.selected)"
             @click="exportModels()"
             outlined
             small
@@ -126,7 +145,7 @@
             Export
           </v-btn>
           <v-btn
-            :disabled="!appState.dialog.data.models.some(p => p.state.selected)"
+            :disabled="!appState.dialog.data.models.some(m => m.state.selected)"
             @click="deleteModels()"
             outlined
             small
@@ -199,6 +218,26 @@ export default Vue.extend({
       reloadModels();
     };
 
+    /**
+     * Selects all models in the list.
+     */
+    function selectAll() {
+      appState.dialog.data.models.forEach((model: Model) => {
+        model.state.selected = true;
+        console.log('Selected');
+      });
+    }
+
+    /**
+     * Unselects all models in the list.
+     */
+    function unselectAll() {
+      appState.dialog.data.models.forEach((model: Model) => {
+        model.state.selected = false;
+        console.log('Unselected');
+      });
+    }
+
     return {
       appState,
       closeDialog: () => core.app.closeDialog(),
@@ -206,6 +245,8 @@ export default Vue.extend({
       exportModels,
       reloadModels,
       resetModels,
+      selectAll,
+      unselectAll,
     };
   },
 });

--- a/src/components/dialog/ProjectsDialog.vue
+++ b/src/components/dialog/ProjectsDialog.vue
@@ -168,7 +168,7 @@
                 </tr>
               </tbody>
               <tbody v-else>
-                No projects found
+                No projects saved in this browser session were found.
               </tbody>
             </template>
           </v-simple-table>
@@ -177,6 +177,22 @@
         <v-card-actions>
           <v-spacer />
           <v-btn @click="closeDialog" outlined small text v-text="'cancel'" />
+          <v-btn
+            :disabled="dialogState.data.projects.every(p => p.state.selected)"
+            @click="selectAll"
+            outlined
+            small
+            text
+            v-text="'select all'"
+          />
+          <v-btn
+            :disabled="!dialogState.data.projects.some(p => p.state.selected)"
+            @click="unselectAll"
+            outlined
+            small
+            text
+            v-text="'unselect all'"
+          />
           <v-btn
             :disabled="!dialogState.data.projects.some(p => p.state.selected)"
             @click="exportProjects"
@@ -264,6 +280,26 @@ export default Vue.extend({
       core.app.closeDialog();
     };
 
+    /**
+     * Selects all projects in the list.
+     */
+    function selectAll() {
+      dialogState.data.projects.forEach((project: Project) => {
+        project.state.selected = true;
+        console.log('Selected ' + project);
+      });
+    }
+
+    /**
+     * Unselects all projects in the list.
+     */
+    function unselectAll() {
+      dialogState.data.projects.forEach((project: Project) => {
+        project.state.selected = false;
+        console.log('Unselected ' + project);
+      });
+    }
+
     return {
       closeDialog: () => core.app.closeDialog(),
       deleteProjects,
@@ -271,6 +307,8 @@ export default Vue.extend({
       exportProjects,
       reloadProjects,
       resetProjects,
+      selectAll,
+      unselectAll,
       projectStore: core.app.project,
     };
   },


### PR DESCRIPTION
This PR adds "Select all"/"Unselect all" buttons to the model/project export and delete views, since it was very clumsy to achieve that before.