### PR TITLE
Add plot model for firing rate

### DIFF
--- a/src/components/parameter/ParameterEdit.vue
+++ b/src/components/parameter/ParameterEdit.vue
@@ -166,7 +166,12 @@
       </v-card>
     </v-menu>
 
-    <v-card @contextmenu="e => showMenu(e)" flat tile>
+    <v-card
+      @contextmenu="showMenu"
+      flat
+      tile
+      v-show="!state.options.hasOwnProperty('show') || state.options.show"
+    >
       <v-row class="px-1 my-0" no-gutters>
         <v-col cols="12">
           <template v-if="state.param && !state.param.isConstant">
@@ -306,9 +311,6 @@
                 class="ma-1 mt-3"
                 dense
                 hide-details
-                v-show="
-                  !state.options.hasOwnProperty('show') || state.options.show()
-                "
               />
             </template>
 

--- a/src/core/activity/activityChart/activityChartGraph.ts
+++ b/src/core/activity/activityChart/activityChartGraph.ts
@@ -6,6 +6,7 @@ import { Project } from '../../project/project';
 import { AnalogSignalHistogramModel } from './activityChartPanelModels/analogSignalHistogramModel';
 import { AnalogSignalPlotModel } from './activityChartPanelModels/analogSignalPlotModel';
 import { CVISIHistogramModel } from './activityChartPanelModels/CVISIHistogramModel';
+import { FiringRatePlotModel } from './activityChartPanelModels/firingRatePlotModel';
 import { InterSpikeIntervalHistogramModel } from './activityChartPanelModels/interSpikeIntervalHistogramModel';
 import { SenderCVISIPlotModel } from './activityChartPanelModels/senderCVISIPlotModel';
 import { SenderMeanISIPlotModel } from './activityChartPanelModels/senderMeanISIPlotModel';
@@ -46,6 +47,13 @@ export class ActivityChartGraph {
       id: 'spikeTimesHistogram',
       icon: 'mdi-chart-bar',
       label: 'Spike times',
+    },
+    {
+      activityType: 'spike',
+      component: FiringRatePlotModel,
+      id: 'firingRatePlot',
+      icon: 'mdi-chart-bell-curve-cumulative',
+      label: 'Firing rate',
     },
     {
       activityType: 'spike',
@@ -116,7 +124,7 @@ export class ActivityChartGraph {
         ],
         ['zoom2d', 'pan2d'],
         ['zoomIn2d', 'zoomOut2d', 'autoScale2d', 'resetScale2d'],
-        ['hoverClosestCartesian', 'hoverCompareCartesian'],
+        ['hoverClosestCartesian', 'hoverCompareCartesian', 'toggleSpikelines'],
       ],
       scrollZoom: true,
     };

--- a/src/core/activity/activityChart/activityChartGraph.ts
+++ b/src/core/activity/activityChart/activityChartGraph.ts
@@ -6,7 +6,7 @@ import { Project } from '../../project/project';
 import { AnalogSignalHistogramModel } from './activityChartPanelModels/analogSignalHistogramModel';
 import { AnalogSignalPlotModel } from './activityChartPanelModels/analogSignalPlotModel';
 import { CVISIHistogramModel } from './activityChartPanelModels/CVISIHistogramModel';
-import { FiringRatePlotModel } from './activityChartPanelModels/firingRatePlotModel';
+import { SpikeCountPlotModel } from './activityChartPanelModels/spikeCountPlotModel';
 import { InterSpikeIntervalHistogramModel } from './activityChartPanelModels/interSpikeIntervalHistogramModel';
 import { SenderCVISIPlotModel } from './activityChartPanelModels/senderCVISIPlotModel';
 import { SenderMeanISIPlotModel } from './activityChartPanelModels/senderMeanISIPlotModel';
@@ -50,10 +50,10 @@ export class ActivityChartGraph {
     },
     {
       activityType: 'spike',
-      component: FiringRatePlotModel,
-      id: 'firingRatePlot',
+      component: SpikeCountPlotModel,
+      id: 'spikeCountPlot',
       icon: 'mdi-chart-bell-curve-cumulative',
-      label: 'Firing rate',
+      label: 'Spike count',
     },
     {
       activityType: 'spike',

--- a/src/core/activity/activityChart/activityChartPanelModels/firingRatePlotModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/firingRatePlotModel.ts
@@ -1,0 +1,129 @@
+import { ActivityChartPanel } from '../activityChartPanel';
+import { SpikeActivity } from '../../spikeActivity';
+import { SpikeTimesPanelModel } from './spikeTimesPanelModel';
+import { Source } from 'three';
+import { Node } from '@/core/node/node';
+import { sum } from 'mathjs';
+import * as d3 from 'd3';
+
+export class FiringRatePlotModel extends SpikeTimesPanelModel {
+  constructor(panel: ActivityChartPanel, model: any = {}) {
+    super(panel, model);
+    this.icon = 'mdi-chart-bell-curve-cumulative';
+    this.id = 'firingRatePlot';
+    this.label = 'Firing rate';
+    this.panel.xaxis = 1;
+    this.params = [
+      {
+        id: 'binSize',
+        input: 'tickSlider',
+        label: 'bin size',
+        ticks: [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000],
+        unit: 'ms',
+        value: 1,
+      },
+      {
+        id: 'normedValue',
+        input: 'checkbox',
+        label: 'normed value',
+        value: false,
+      },
+    ];
+
+    this.initParams(model.params);
+  }
+
+  get binSize(): number {
+    return this.params[0].value;
+  }
+
+  get normedValue(): boolean {
+    return this.params[1].value;
+  }
+
+  /**
+   * Calculate simple histogram
+   * 
+   * @param data 
+   * @param min 
+   * @param max 
+   * @param size 
+   * @returns histogram
+   * 
+   * See https://stackoverflow.com/questions/36266895/simple-histogram-algorithm-in-javascript
+   */
+  histogram(data: number[], min: number = -Infinity, max: number = Infinity, size: number = 1): number[] {
+    for (const item of data) {
+        if (item < min) min = item;
+        else if (item > max) max = item;
+    }
+
+    const bins = Math.ceil((max - min + 1) / size);
+    const histogram = new Array(bins).fill(0);
+    for (const item of data) {
+        histogram[Math.floor((item - min) / size )]++;
+    }
+
+    return histogram;
+}
+
+/**
+ * Calculate range
+ * @param size number
+ * @param startAt number
+ * @returns number Array
+ */
+range(start: number=0, stop:number, step:number = 1): number[] {
+  return Array(Math.ceil((stop - start) / step)).fill(start).map((x, y) => x + y * step)
+}
+
+
+
+  /**
+   * Add data of spike times for histogram panel.
+   */
+  override addData(activity: SpikeActivity): void {
+    if (activity.nodeIds.length === 0) return;
+
+    const nodesLength = sum(activity.recorder.nodes.map((node: Node) => node.size));
+    const times: number[] = activity.events.times;
+    const start: number = this.state.time.start;
+    const end: number = this.state.time.end;
+    const size: number = this.binSize;
+
+    const x: number[] = this.range(start, end, size);
+    const h: number[] = this.histogram(times, start, end, size);
+
+    let y: number[];
+    if (this.normedValue) {
+      const hExtent = d3.extent(h);
+      y = h.map((val: number) => (val - hExtent[0]) / hExtent[1]);
+    } else {
+      y = h.map((val: number) => val / nodesLength / size * 1000);
+    }
+
+    this.data.push({
+      activityIdx: activity.idx,
+      hoverinfo: 'x+y',
+      legendgroup: 'spikes' + activity.idx,
+      line: {
+        color: activity.recorder.view.color,
+        width: 1.5,
+      },
+      mode: 'lines',
+      showlegend: false,
+      type: 'scattergl',
+      visible: this.state.visible,
+      x,
+      y,
+    });
+  }
+
+  /**
+   * Update layout label for spike time histogram.
+   */
+  override updateLayoutLabel(): void {
+    this.panel.layout.xaxis.title = 'Time [ms]';
+    this.panel.layout.yaxis.title = this.normedValue ? 'Normed' : 'Firing rate [spikes/s]';
+  }
+}

--- a/src/core/activity/activityChart/activityChartPanelModels/senderCVISIPlotModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/senderCVISIPlotModel.ts
@@ -11,11 +11,17 @@ export class SenderCVISIPlotModel extends SpikeTimesPanelModel {
     this.panel.xaxis = 4;
     this.params = [
       {
+        _parent: this,
+        _value: 'bar',
         id: 'plotMode',
         input: 'select',
         items: ['lines', 'lines+markers', 'markers', 'bar'],
         label: 'Plot mode',
-        value: 'bar',
+        get value(): string { return this._value },
+        set value(value: string) {
+          this._value = value;
+          this._parent.params[1].show = value.includes('lines')
+        }
       },
       {
         id: 'lineShape',
@@ -29,7 +35,7 @@ export class SenderCVISIPlotModel extends SpikeTimesPanelModel {
           { text: 'horizontal-vertical steps', value: 'hv' },
         ],
         label: 'Line shape',
-        show: () => this.plotMode.includes('lines'),
+        show: false,
         value: 'linear',
       },
     ];

--- a/src/core/activity/activityChart/activityChartPanelModels/senderMeanISIPlotModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/senderMeanISIPlotModel.ts
@@ -11,11 +11,18 @@ export class SenderMeanISIPlotModel extends SpikeTimesPanelModel {
     this.panel.xaxis = 4;
     this.params = [
       {
+        _parent: this,
+        _value: 'bar',
         id: 'plotMode',
         input: 'select',
         items: ['lines', 'lines+markers', 'markers', 'bar'],
         label: 'Plot mode',
-        value: 'bar',
+        parent: this,
+        get value(): string { return this._value },
+        set value(value: string) {
+          this._value = value;
+          this._parent.params[1].show = value.includes('lines')
+        }
       },
       {
         id: 'lineShape',
@@ -29,7 +36,7 @@ export class SenderMeanISIPlotModel extends SpikeTimesPanelModel {
           { text: 'horizontal-vertical steps', value: 'hv' },
         ],
         label: 'Line shape',
-        show: () => this.plotMode.includes('lines'),
+        show: false,
         value: 'linear',
       },
     ];

--- a/src/core/activity/activityChart/activityChartPanelModels/senderSpikeCountPlotModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/senderSpikeCountPlotModel.ts
@@ -11,11 +11,17 @@ export class SenderSpikeCountPlotModel extends SpikeTimesPanelModel {
     this.panel.xaxis = 4;
     this.params = [
       {
+        _parent: this,
+        _value: 'bar',
         id: 'plotMode',
         input: 'select',
         items: ['lines', 'lines+markers', 'markers', 'bar'],
         label: 'Plot mode',
-        value: 'bar',
+        get value(): string { return this._value },
+        set value(value: string) {
+          this._value = value;
+          this._parent.params[1].show = value.includes('lines')
+        }
       },
       {
         id: 'lineShape',
@@ -29,7 +35,7 @@ export class SenderSpikeCountPlotModel extends SpikeTimesPanelModel {
           { text: 'horizontal-vertical steps', value: 'hv' },
         ],
         label: 'Line shape',
-        show: () => this.plotMode.includes('lines'),
+        show: false,
         value: 'linear',
       },
       {

--- a/src/core/activity/activityChart/activityChartPanelModels/spikeCountPlotModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/spikeCountPlotModel.ts
@@ -126,6 +126,7 @@ export class SpikeCountPlotModel extends SpikeTimesPanelModel {
 
   /**
    * Add data of spike times for histogram panel.
+   * TODO: Improve checks (div-0-error, ...).
    */
   override addData(activity: SpikeActivity): void {
     if (activity.nodeIds.length === 0) return;

--- a/src/core/activity/activityChart/activityChartPanelModels/spikeCountPlotModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/spikeCountPlotModel.ts
@@ -1,10 +1,10 @@
+import * as d3 from 'd3';
 import { ActivityChartPanel } from '../activityChartPanel';
+import { Node } from '@/core/node/node';
+import { Source } from 'three';
 import { SpikeActivity } from '../../spikeActivity';
 import { SpikeTimesPanelModel } from './spikeTimesPanelModel';
-import { Source } from 'three';
-import { Node } from '@/core/node/node';
 import { sum } from 'mathjs';
-import * as d3 from 'd3';
 
 export class SpikeCountPlotModel extends SpikeTimesPanelModel {
   constructor(panel: ActivityChartPanel, model: any = {}) {
@@ -41,6 +41,7 @@ export class SpikeCountPlotModel extends SpikeTimesPanelModel {
         set value(value: string) {
           this._value = value;
           this._parent.params[2].show = value.startsWith('lower-upper');
+          this._parent.params[3].show = value.startsWith('lower-upper');
         },
       },
       {
@@ -52,6 +53,13 @@ export class SpikeCountPlotModel extends SpikeTimesPanelModel {
         unit: 'ms',
         value: 1,
       },
+      {
+        id: 'horizontalLine',
+        input: 'checkbox',
+        label: 'Horizontal line for time constant (63%)',
+        show: false,
+        value: false,
+      }
     ];
 
     this.initParams(model.params);
@@ -59,14 +67,18 @@ export class SpikeCountPlotModel extends SpikeTimesPanelModel {
 
   get binSize(): number {
     return this.params[0].value;
-  }
-
-  get normalization(): string {
-    return this.params[1].value;
+  }  
+  
+  get horizontalLine(): string {
+    return this.params[3].value;
   }
 
   get lowerUpperBinSize(): number {
     return this.params[2].value;
+  }
+
+  get normalization(): string {
+    return this.params[1].value;
   }
 
   /**
@@ -170,6 +182,25 @@ export class SpikeCountPlotModel extends SpikeTimesPanelModel {
       x,
       y,
     });
+
+    if (this.horizontalLine) {
+      this.data.push({
+        activityIdx: activity.idx,
+        hoverinfo: 'none',
+        legendgroup: 'spikes' + activity.idx,
+        line: {
+          color: 'red',
+          dash: 'dot',
+          width: 1,
+        },
+        mode: 'lines',
+        showlegend: false,
+        type: 'scattergl',
+        visible: this.state.visible,
+        x: [start, end],
+        y: [0.63, 0.63],
+      });
+    }
   }
 
   /**

--- a/src/core/activity/activityChart/activityChartPanelModels/spikeCountPlotModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/spikeCountPlotModel.ts
@@ -17,7 +17,7 @@ export class SpikeCountPlotModel extends SpikeTimesPanelModel {
       {
         id: 'binSize',
         input: 'tickSlider',
-        label: 'bin size',
+        label: 'Bin size',
         ticks: [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000],
         unit: 'ms',
         value: 1,
@@ -32,13 +32,13 @@ export class SpikeCountPlotModel extends SpikeTimesPanelModel {
           'lower-upper averages scale', 
           'standard score'
         ],
-        label: 'normalization',
+        label: 'Normalization',
         value: 'off',
       },
       {
         id: 'lowerUpperBinSize',
         input: 'tickSlider',
-        label: 'bin size for lower-upper averages',
+        label: 'Bin size for lower-upper averages',
         ticks: [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000],
         unit: 'ms',
         value: 1,


### PR DESCRIPTION
This PR adds a plot model for firing rate.

It is useful to measure time constant of the recurrent network.

Example projects:
https://github.com/nest-desktop/nest-desktop-projects/blob/main/network_models/recurrent_network_time_constant.json

