### PR TITLE
Fix reload loops when user wants to create a new project

### DIFF
--- a/src/components/navigation/ProjectNavList.vue
+++ b/src/components/navigation/ProjectNavList.vue
@@ -159,7 +159,7 @@ export default Vue.extend({
           id: 'newProject',
           icon: 'mdi-plus',
           title: 'New project',
-          to: '/project/',
+          to: '/project',
           onClick: () => {},
         },
         {

--- a/src/views/Project.vue
+++ b/src/views/Project.vue
@@ -240,12 +240,15 @@ export default Vue.extend({
         });
       } else {
         projectView.init().then(() => {
-          const project = projectView.state.project;
-          if (!root.$route.path.endsWith(project.id)) {
-            root.$router.push({
-              path: `/project/${project.id}`,
-            });
-          }
+          setTimeout(() => {
+            const project = projectView.state.project;
+            // Create a new project when route path doesn't match with valid project id.
+            if (!root.$route.path.endsWith(project.id)) {
+              root.$router.push({
+                path: `/project`,
+              });
+            }
+          })
         });
       }
     };


### PR DESCRIPTION
This PR fixes the bug of reload loops when
- user wants to create a new project
- the project id is not found