### PR TITLE
Remove push to docker hub

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,39 +166,6 @@ deploy_docker_hub_nestsim:
     - read-only
 
 #
-# DEPLOY DOCKER IMAGE ON DOCKER HUB in nestdesktop organisation
-#
-
-deploy_docker_hub_nestdesktop:
-  stage: deploy
-  image: ubuntu:22.04
-  needs:
-    - build_app
-  rules:
-    - if: $CI_COMMIT_TAG
-      when: never
-    - if: '$CI_PIPELINE_SOURCE == "push"'
-      when: manual
-  before_script:
-    - source .env
-    - echo "${DOCKER_HUB_ACCESS_TOKEN}" | docker login -u ${DOCKER_HUB_ACCESS_USER} --password-stdin
-  script:
-    - docker build -f docker/Dockerfile -t nestdesktop/app:${DOCKER_TAG} .
-    - |-
-      if [[ $CI_COMMIT_BRANCH == "main" ]]; then
-        docker tag nestdesktop/app:${DOCKER_TAG} nestdesktop/app:${DOCKER_TAG%.*}
-        docker tag nestdesktop/app:${DOCKER_TAG} nestdesktop/app:latest
-      else
-        docker tag nestdesktop/app:${DOCKER_TAG} nestdesktop/app:dev
-      fi
-    - docker push nestdesktop/app --all-tags
-  after_script:
-    - docker logout
-  tags:
-    - shell-runner
-    - read-only
-
-#
 # DEPLOY SNAP ON SNAPCRAFT
 #
 


### PR DESCRIPTION
This PR removes lines to push docker image to `nestdesktop/app` which is not pulled in last 7 month.
People prefer use `nestsim/nest-desktop` instead.