### PR TITLE
Fix regex match for number

### DIFF
--- a/src/components/parameter/ParameterEdit.vue
+++ b/src/components/parameter/ParameterEdit.vue
@@ -702,7 +702,7 @@ export default Vue.extend({
     /**
      * Check if the string contains only a number.
      */
-    const containsOnlyNumber = (value: string) => /^\d.?\d?$/.test(value);
+    const containsOnlyNumber = (value: string) => /^([0-9]+[.])?[0-9]*$/.test(value);
 
     /**
      * Triggers when parameter is changed.

--- a/src/components/parameter/ParameterEdit.vue
+++ b/src/components/parameter/ParameterEdit.vue
@@ -702,7 +702,7 @@ export default Vue.extend({
     /**
      * Check if the string contains only a number.
      */
-    const containsOnlyNumber = (value: string) => /^([0-9]+[.])?[0-9]*$/.test(value);
+    const containsOnlyNumber = (value: string) => /^[0-9]+([.][0-9]*)?$/.test(value);
 
     /**
      * Triggers when parameter is changed.


### PR DESCRIPTION
This PR fixes bug that produces NaN when user enter `1,1` 
in text area for parameters, e.g. spike times in spike generator.