### PR TITLE
[BigBang] Extend Insite workflow

### DIFF
--- a/src/components/activity/ActivityGraph.vue
+++ b/src/components/activity/ActivityGraph.vue
@@ -9,8 +9,19 @@
         label
         outlined
         small
-        v-if="state.graph.codeHash"
-        v-text="state.graph.codeHash.slice(0, 6)"
+        title="Code hash"
+        v-if="state.graph.state.codeHash"
+        v-text="state.graph.state.codeHash.slice(0, 6)"
+      />
+      <v-chip
+        :key="state.graph.state.dataHash"
+        class="ma-1"
+        label
+        outlined
+        small
+        title="Data hash"
+        v-if="state.graph.state.dataHash"
+        v-text="state.graph.state.dataHash.slice(0, 6)"
       />
     </div>
 

--- a/src/core/activity/activity.ts
+++ b/src/core/activity/activity.ts
@@ -154,9 +154,7 @@ export class Activity {
    * Extends events.
    */
   update(activity: any): void {
-    if (activity.events == undefined) {
-      return;
-    }
+    if (activity.events == undefined) return;
 
     this.updateEvents(activity.events);
     this.postUpdate(activity);
@@ -170,19 +168,31 @@ export class Activity {
    * Update events.
    */
   updateEvents(events: any): void {
+    if (events === undefined) return;
+    let updated = false;
+
     const eventKeys: string[] = Object.keys(events);
+    if (eventKeys === undefined || eventKeys.length === 0) return;
+
     eventKeys.forEach((eventKey: string) => {
       const newEvents: number[] = events[eventKey];
-      this._events[eventKey] = this._events[eventKey].concat(newEvents);
+      if (newEvents !== undefined || newEvents.length > 0) {
+        this._events[eventKey] = this._events[eventKey].concat(newEvents);
+        updated = true;
+      }
     });
-    this.updateHash();
+
+    if (updated) {
+      this.updateHash();
+    }
   }
 
   /**
    * Update hash.
    */
   updateHash(): void {
-    this._hash = sha1(JSON.stringify(this._events));
+    // this._hash = sha1(JSON.stringify(this._events));
+    this._hash = sha1({ sendersLength: this._events.senders.length });
   }
 
   /**

--- a/src/core/activity/activity.ts
+++ b/src/core/activity/activity.ts
@@ -168,11 +168,11 @@ export class Activity {
    * Update events.
    */
   updateEvents(events: any): void {
-    if (events === undefined) return;
+    if (events == undefined) return;
     let updated = false;
 
     const eventKeys: string[] = Object.keys(events);
-    if (eventKeys === undefined || eventKeys.length === 0) return;
+    if (eventKeys == undefined || eventKeys.length === 0) return;
 
     eventKeys.forEach((eventKey: string) => {
       const newEvents: number[] = events[eventKey];

--- a/src/core/activity/activityChart/activityChartPanelModels/spikeCountPlotModel.ts
+++ b/src/core/activity/activityChart/activityChartPanelModels/spikeCountPlotModel.ts
@@ -59,7 +59,7 @@ export class SpikeCountPlotModel extends SpikeTimesPanelModel {
         label: 'Horizontal line for time constant (63%)',
         show: false,
         value: false,
-      }
+      },
     ];
 
     this.initParams(model.params);
@@ -67,8 +67,8 @@ export class SpikeCountPlotModel extends SpikeTimesPanelModel {
 
   get binSize(): number {
     return this.params[0].value;
-  }  
-  
+  }
+
   get horizontalLine(): string {
     return this.params[3].value;
   }

--- a/src/core/activity/analogSignalActivity.ts
+++ b/src/core/activity/analogSignalActivity.ts
@@ -24,6 +24,8 @@ export class AnalogSignalActivity extends Activity {
    * Update records from recorder.
    */
   updateActivityRecords(): void {
+    if (this.recorder.records.length === 0) return;
+
     this.state.records = [...this.recorder.records];
   }
 
@@ -33,48 +35,5 @@ export class AnalogSignalActivity extends Activity {
    */
   override clone(): AnalogSignalActivity {
     return new AnalogSignalActivity(this.recorder, this.toJSON());
-  }
-
-  repeat(data: any): number[] {
-    return data.simulationTimes.flatMap((e: number) =>
-      Array(data.nodeIds.length).fill(e)
-    );
-  }
-
-  tile(data: any): number[] {
-    return data.simulationTimes.flatMap(() => data.nodeIds);
-  }
-
-  /**
-   * Get activity from Insite.
-   */
-  override getActivityInsite(): void {
-    if (!this.project.insite.state.on) {
-      return;
-    }
-
-    const attribute: string = 'V_m';
-    const path = `nest/multimeters/${this.recorderUnitId}/attributes/${attribute}/?fromTime=${this.lastTime}`;
-    this.project.app.backends.insiteAccess.instance
-      .get(path)
-      .then((response: any) => {
-        const times: number[] = this.repeat(response.data);
-        const senders: number[] = this.tile(response.data);
-        const activity: any = {
-          events: {
-            times, // x
-            senders,
-          },
-          nodeIds: response.data.nodeIds, // from insite
-          times: response.data.simulationTimes, // from insite
-        };
-        activity.events[attribute] = response.data.values;
-        this.update(activity);
-
-        // Recursive call after 100ms.
-        setTimeout(() => {
-          this.getActivityInsite();
-        }, 100);
-      });
   }
 }

--- a/src/core/activity/spikeActivity.ts
+++ b/src/core/activity/spikeActivity.ts
@@ -14,6 +14,8 @@ export class SpikeActivity extends Activity {
    */
   override postInit(): void {
     this._times = Object.create(null);
+    if (this.nodeIds.length === 0) return;
+
     this.nodeIds.forEach((id: number) => (this._times[id] = []));
     this.updateTimes(this.events);
   }
@@ -22,6 +24,7 @@ export class SpikeActivity extends Activity {
    * Post-update spike activity.
    */
   override postUpdate(activity: any): void {
+    if (activity.events === undefined) return;
     this.updateTimes(activity.events);
   }
 
@@ -29,6 +32,15 @@ export class SpikeActivity extends Activity {
    * Update times for ISI or CV(ISI).
    */
   updateTimes(events: any): void {
+    if (
+      events.senders === undefined ||
+      events.times === undefined ||
+      events.senders.length === 0 ||
+      events.times.length === 0
+    ) {
+      return;
+    }
+
     events.senders.forEach((sender: number, idx: number) => {
       this._times[sender].push(this.events.times[idx]);
     });
@@ -90,33 +102,5 @@ export class SpikeActivity extends Activity {
    */
   override clone(): SpikeActivity {
     return new SpikeActivity(this.recorder, this.toJSON());
-  }
-
-  /**
-   * Get activity from Insite.
-   */
-  override getActivityInsite(): void {
-    if (!this.project.insite.state.on) {
-      return;
-    }
-
-    const path = `nest/spikerecorders/${this.recorderUnitId}/spikes/?fromTime=${
-      this.lastTime + 0.1
-    }`;
-    this.project.app.backends.insiteAccess.instance
-      .get(path)
-      .then((response: any) => {
-        this.update({
-          events: {
-            senders: response.data.nodeIds, // y
-            times: response.data.simulationTimes, // x
-          },
-        });
-
-        // Recursive call after 500ms.
-        setTimeout(() => {
-          this.getActivityInsite();
-        }, 500);
-      });
   }
 }

--- a/src/core/activity/spikeActivity.ts
+++ b/src/core/activity/spikeActivity.ts
@@ -24,7 +24,7 @@ export class SpikeActivity extends Activity {
    * Post-update spike activity.
    */
   override postUpdate(activity: any): void {
-    if (activity.events === undefined) return;
+    if (activity.events == undefined) return;
     this.updateTimes(activity.events);
   }
 
@@ -33,8 +33,8 @@ export class SpikeActivity extends Activity {
    */
   updateTimes(events: any): void {
     if (
-      events.senders === undefined ||
-      events.times === undefined ||
+      events.senders == undefined ||
+      events.times == undefined ||
       events.senders.length === 0 ||
       events.times.length === 0
     ) {

--- a/src/core/project/project.ts
+++ b/src/core/project/project.ts
@@ -436,7 +436,7 @@ export class Project {
    */
   startSimulation(): void {
     // Stop getting activities from Insite.
-    this.insite.cancelGettingActivity();
+    this.insite.cancelAllIntervals();
 
     // Reset activities and activity graphs.
     this.resetActivities();
@@ -459,7 +459,13 @@ export class Project {
     });
 
     if (this._simulation.code.runSimulationInsite) {
-      // Get activities from the Insite Access Node.
+      // Update time info during the simulation.
+      this.insite.continuouslyUpdateSimulationTimeInfo(250);
+
+      // Update activity graph during the simulation.
+      this.insite.continuouslyUpdateActivityGraph(500);
+
+      // Get activities from Insite.
       this.insite.getActivities();
     }
   }

--- a/src/core/project/projectStore.ts
+++ b/src/core/project/projectStore.ts
@@ -212,6 +212,7 @@ export class ProjectStore {
    */
   loadProject(project: any): void {
     this.consoleLog('Load project');
+    this.project.insite.cancelAllIntervals();
     const projectIds = this._state.projects.map((project: any) => project.id);
     const projectIdx = projectIds.indexOf(project.id);
     if (project.doc == undefined) {

--- a/src/core/project/projectView.ts
+++ b/src/core/project/projectView.ts
@@ -71,7 +71,6 @@ export class ProjectView extends Config {
     // Global state for project view.
     this._state = reactive({
       activityGraph: 'abstract',
-      fromTime: 0,
       modeIdx: 0,
       networkGraphHeight: 'calc(100vh - 48px)',
       project: new Project(this._app),


### PR DESCRIPTION
This PR initially fixes empty node ids from Insite using 202 status.

Additional features were implemented.
- [x] multiple intervals for updating: `activityGraph` and `simulationTimeInfo`.
- [x] use `dataHash` in `activityGraph.ts` to improve performance (no graph rendering when same dataset).
- [ ] increase interval when simulation is finished (The codes were commented).
- [x] fix simulation time info for histogram of spike count.
- [x] several failsafe codes.
- [x] send requests to '/nest/spikes' to synchronize activity updates of various populations.
- [x] use `top` and `skip` arguments to get spikes of all populations.