### PR TITLE
Fix code generation when node has grid positions

### DIFF
--- a/src/core/node/nodeSpatial/nodeSpatial.ts
+++ b/src/core/node/nodeSpatial/nodeSpatial.ts
@@ -20,6 +20,10 @@ export class NodeSpatial extends Config {
     return this.positions ? this.positions.toPythonCode() : '';
   }
 
+  get hasGridPositions(): boolean {
+    return this._positions?.name === 'grid';
+  }
+
   get hash(): string {
     return this._hash;
   }

--- a/src/core/simulation/simulationCodes/cosim-v2.0.code
+++ b/src/core/simulation/simulationCodes/cosim-v2.0.code
@@ -31,7 +31,7 @@ def configure_nest(nest, addresses):
 
   # Create nodes
   {{ #network.nodes }}
-  {{ view.label }} = nest.Create("{{ modelId }}", {{ n }}{{ #hasSomeVisibleParams }}, params={
+  {{ view.label }} = nest.Create("{{ modelId }}"{{ ^spatial.hasGridPositions }}, {{ n }}{{ /spatial.hasGridPositions }}{{ #hasSomeVisibleParams }}, params={
   {{ #filteredParams }}
     "{{ id }}": {{ code }},
   {{ /filteredParams }}

--- a/src/core/simulation/simulationCodes/nest-master.code
+++ b/src/core/simulation/simulationCodes/nest-master.code
@@ -37,7 +37,7 @@ nest.CopyModel("{{ existingModelId }}", "{{ newModelId }}"{{ #hasSomeVisiblePara
 
 # Create nodes
 {{ #network.nodes }}
-{{ view.label }} = nest.Create("{{ modelId }}", {{ n }}{{ #hasSomeVisibleParams }}, params={
+{{ view.label }} = nest.Create("{{ modelId }}"{{ ^spatial.hasGridPositions }}, {{ n }}{{ /spatial.hasGridPositions }}{{ #hasSomeVisibleParams }}, params={
 {{ #filteredParams }}
   "{{ id }}": {{ code }},
 {{ /filteredParams }}

--- a/src/core/simulation/simulationCodes/nest-v3.0.code
+++ b/src/core/simulation/simulationCodes/nest-v3.0.code
@@ -37,7 +37,7 @@ nest.CopyModel("{{ existingModelId }}", "{{ newModelId }}"{{ #hasSomeVisiblePara
 
 # Create nodes
 {{ #network.nodes }}
-{{ view.label }} = nest.Create("{{ modelId }}", {{ n }}{{ #hasSomeVisibleParams }}, params={
+{{ view.label }} = nest.Create("{{ modelId }}"{{ ^spatial.hasGridPositions }}, {{ n }}{{ /spatial.hasGridPositions }}{{ #hasSomeVisibleParams }}, params={
 {{ #filteredParams }}
   "{{ id }}": {{ valueFixed }},
 {{ /filteredParams }}

--- a/src/core/simulation/simulationCodes/nest-v3.1.code
+++ b/src/core/simulation/simulationCodes/nest-v3.1.code
@@ -37,7 +37,7 @@ nest.CopyModel("{{ existingModelId }}", "{{ newModelId }}"{{ #hasSomeVisiblePara
 
 # Create nodes
 {{ #network.nodes }}
-{{ view.label }} = nest.Create("{{ modelId }}", {{ n }}{{ #hasSomeVisibleParams }}, params={
+{{ view.label }} = nest.Create("{{ modelId }}"{{ ^spatial.hasGridPositions }}, {{ n }}{{ /spatial.hasGridPositions }}{{ #hasSomeVisibleParams }}, params={
 {{ #filteredParams }}
   "{{ id }}": {{ &valueAsString }},
 {{ /filteredParams }}

--- a/src/core/simulation/simulationCodes/nest-v3.2.code
+++ b/src/core/simulation/simulationCodes/nest-v3.2.code
@@ -37,7 +37,7 @@ nest.CopyModel("{{ existingModelId }}", "{{ newModelId }}"{{ #hasSomeVisiblePara
 
 # Create nodes
 {{ #network.nodes }}
-{{ view.label }} = nest.Create("{{ modelId }}", {{ n }}{{ #hasSomeVisibleParams }}, params={
+{{ view.label }} = nest.Create("{{ modelId }}"{{ ^spatial.hasGridPositions }}, {{ n }}{{ /spatial.hasGridPositions }}{{ #hasSomeVisibleParams }}, params={
 {{ #filteredParams }}
   "{{ id }}": {{ code }},
 {{ /filteredParams }}

--- a/src/core/simulation/simulationCodes/nest-v3.3.code
+++ b/src/core/simulation/simulationCodes/nest-v3.3.code
@@ -37,7 +37,7 @@ nest.CopyModel("{{ existingModelId }}", "{{ newModelId }}"{{ #hasSomeVisiblePara
 
 # Create nodes
 {{ #network.nodes }}
-{{ view.label }} = nest.Create("{{ modelId }}", {{ n }}{{ #hasSomeVisibleParams }}, params={
+{{ view.label }} = nest.Create("{{ modelId }}"{{ ^spatial.hasGridPositions }}, {{ n }}{{ /spatial.hasGridPositions }}{{ #hasSomeVisibleParams }}, params={
 {{ #filteredParams }}
   "{{ id }}": {{ code }},
 {{ /filteredParams }}

--- a/src/core/simulation/simulationCodes/nest-v3.4.code
+++ b/src/core/simulation/simulationCodes/nest-v3.4.code
@@ -37,7 +37,7 @@ nest.CopyModel("{{ existingModelId }}", "{{ newModelId }}"{{ #hasSomeVisiblePara
 
 # Create nodes
 {{ #network.nodes }}
-{{ view.label }} = nest.Create("{{ modelId }}", {{ n }}{{ #hasSomeVisibleParams }}, params={
+{{ view.label }} = nest.Create("{{ modelId }}"{{ ^spatial.hasGridPositions }}, {{ n }}{{ /spatial.hasGridPositions }}{{ #hasSomeVisibleParams }}, params={
 {{ #filteredParams }}
   "{{ id }}": {{ code }},
 {{ /filteredParams }}


### PR DESCRIPTION
Nodes with grid positions doesn't need size in the scripted code. 