### PR TITLE
Access token to authorize requests to backends.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -83,9 +83,9 @@ export default Vue.extend({
     };
 
     /**
-     * Store parameter from URL.
+     * Get parameter from URL.
      */
-    const storeParamFromURL = (route: Route, paramKey: string) => {
+    const getParamFromURL = (route: Route, paramKey: string) => {
       let param: string;
       if (route.query[paramKey]) {
         param = route.query[paramKey] as string;
@@ -94,9 +94,7 @@ export default Vue.extend({
       } else {
         param = new URLSearchParams(window.location.search).get(paramKey);
       }
-      if (param) {
-        localStorage.setItem(paramKey, param);
-      }
+      return param;
     };
 
     onMounted(() => {
@@ -120,12 +118,16 @@ export default Vue.extend({
     });
 
     onUpdated(() => {
+      const nestServerAccessToken = 'nest_server_access_token';
+
+      // Store access token for NEST Server.
+      const token = getParamFromURL(context.root.$route, nestServerAccessToken);
+      if (token) {
+        localStorage.setItem(nestServerAccessToken, token);
+      }
 
       // Update access token for NEST Server.
-      storeParamFromURL(context.root.$route, 'nest_server_access_token');
-      core.app.backends.nestSimulator.updateAuthToken(
-        'nest_server_access_token'
-      );
+      core.app.backends.nestSimulator.updateAuthToken(nestServerAccessToken);
 
       // Check if backends is running.
       core.app.checkBackends().then(() => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -118,15 +118,21 @@ export default Vue.extend({
     });
 
     onUpdated(() => {
-      const nestServerAccessToken = 'nest_server_access_token';
+      const nestServerURL = getParamFromURL(
+        context.root.$route,
+        'nest_server_url'
+      );
+      if (nestServerURL) {
+        core.app.backends.nestSimulator.url = nestServerURL;
+      }
 
-      // Store access token for NEST Server.
+      const nestServerAccessToken = 'nest_server_access_token';
+      // Store access token for NEST Server to local storage.
       const token = getParamFromURL(context.root.$route, nestServerAccessToken);
       if (token) {
         localStorage.setItem(nestServerAccessToken, token);
       }
-
-      // Update access token for NEST Server.
+      // Update access token for NEST Server from local storage.
       core.app.backends.nestSimulator.updateAuthToken(nestServerAccessToken);
 
       // Check if backends is running.

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,7 +31,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { onMounted, reactive } from '@vue/composition-api';
+import { onMounted, onUpdated, reactive } from '@vue/composition-api';
 
 import core from '@/core';
 
@@ -81,6 +81,21 @@ export default Vue.extend({
       window.location.reload();
     };
 
+    /**
+     * Get access token from URL.
+     */
+    const getTokenFromURL = () => {
+      let token: string;
+      if (context.root.$route.query.token) {
+        token = context.root.$route.query.token as string;
+      } else {
+        token = new URLSearchParams(window.location.search).get('token');
+      }
+      if (token) {
+        localStorage.setItem('token', token);
+      }
+    };
+
     onMounted(() => {
       // Check if new updates existed.
       document.addEventListener('swUpdated', updateAvailable, {
@@ -99,6 +114,16 @@ export default Vue.extend({
         window.onbeforeunload = () =>
           core.app.project.checkSomeProjectChanges() ? '' : null;
       }
+    });
+
+    onUpdated(() => {
+      getTokenFromURL();
+
+      // Check if backends is running.
+      core.app.checkBackends().then(() => {
+        // Fetch models from NEST Simulator.
+        core.app.model.fetchModelsNEST();
+      });
     });
 
     return { core, refreshApp, state };

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { onMounted, onUpdated, reactive } from '@vue/composition-api';
+import { Route } from 'vue-router';
 
 import core from '@/core';
 
@@ -82,17 +83,19 @@ export default Vue.extend({
     };
 
     /**
-     * Get access token from URL.
+     * Store parameter from URL.
      */
-    const getTokenFromURL = () => {
-      let token: string;
-      if (context.root.$route.query.token) {
-        token = context.root.$route.query.token as string;
+    const storeParamFromURL = (route: Route, paramKey: string) => {
+      let param: string;
+      if (route.query[paramKey]) {
+        param = route.query[paramKey] as string;
+      } else if (route.params[paramKey]) {
+        param = route.params[paramKey] as string;
       } else {
-        token = new URLSearchParams(window.location.search).get('token');
+        param = new URLSearchParams(window.location.search).get(paramKey);
       }
-      if (token) {
-        localStorage.setItem('token', token);
+      if (param) {
+        localStorage.setItem(paramKey, param);
       }
     };
 
@@ -117,7 +120,12 @@ export default Vue.extend({
     });
 
     onUpdated(() => {
-      getTokenFromURL();
+
+      // Update access token for NEST Server.
+      storeParamFromURL(context.root.$route, 'nest_server_access_token');
+      core.app.backends.nestSimulator.updateAuthToken(
+        'nest_server_access_token'
+      );
 
       // Check if backends is running.
       core.app.checkBackends().then(() => {

--- a/src/core/app.ts
+++ b/src/core/app.ts
@@ -123,14 +123,8 @@ export class App extends Config {
     // Update configs from global config.
     this.updateConfigs(config);
 
-    // Check if backends is running.
-    this.checkBackends().then(() => {
-      // Fetch models from NEST Simulator.
-      this._model.fetchModelsNEST();
-
-      // Fetch model files from Github.
-      this._model.fetchModelFilesGithub();
-    });
+    // Fetch model files from Github.
+    this._model.fetchModelFilesGithub();
 
     if (
       this.config.intervalCheckBackends > 0 &&

--- a/src/core/common/backend.ts
+++ b/src/core/common/backend.ts
@@ -42,7 +42,6 @@ export class Backend extends Config {
   }
 
   get instance(): AxiosInstance {
-    this.refreshToken();
     return this._instance;
   }
 
@@ -177,13 +176,12 @@ export class Backend extends Config {
   }
 
   /**
-   * Refresh access token in headers.
+   * Update authorization token in instance headers.
    */
-  refreshToken(): void {
-    if (localStorage.getItem('token')) {
-      this._instance.defaults.headers.common[
-        'Authorization'
-      ] = `Bearer ${localStorage.getItem('token')}`;
+  updateAuthToken(itemKey: string): void {
+    const token = localStorage.getItem(itemKey);
+    if (token) {
+      this._instance.defaults.headers.Authorization = `Bearer ${token}`;
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import App from './App.vue';
-import './registerServiceWorker';
-import combineURLs from 'axios/lib/helpers/combineURLs';
+
+import { registerServiceWorker } from './registerServiceWorker';
 
 import router from './router';
 import vuetify from './plugins/vuetify';
@@ -42,8 +42,9 @@ if (process.env.IS_ELECTRON) {
   };
   mountApp();
 } else {
+  registerServiceWorker();
   // Load the data from config.json for the global config and mount the app.
-  fetch(combineURLs(process.env.BASE_URL, 'config/app.json'))
+  fetch('./config/app.json') // use relative path.
     .then(response => response.json())
     .then(appConfig => (Vue.prototype.$appConfig = appConfig))
     .finally(mountApp);

--- a/src/registerServiceWorker.ts
+++ b/src/registerServiceWorker.ts
@@ -2,7 +2,9 @@
 
 import { register } from 'register-service-worker';
 
-if (process.env.NODE_ENV === 'production') {
+export function registerServiceWorker() {
+  if (process.env.NODE_ENV !== 'production') return;
+
   register(`${process.env.BASE_URL}service-worker.js`, {
     ready() {
       console.log(

--- a/vue.config.js
+++ b/vue.config.js
@@ -7,7 +7,7 @@ module.exports = {
   //  https: true,
   //  http2: true,
   //},
-  publicPath: process.env.BASE_URL, // '.',
+  publicPath: process.env.IS_ELECTRON ? process.env.BASE_URL : './',
   outputDir: './nest_desktop/app',
   transpileDependencies: ['vuetify'],
   productionSourceMap: false,


### PR DESCRIPTION
The app takes token from the url, e.g. 
- `http://localhost:54286/#?nest_server_access_token=test` (preferred) or
- `http://localhost:54286?nest_server_access_token=test`.

Then it stores access token value in localStorage and update header in axios instance.
With this method, the request can be authorized by the nest server backend.

Additional feature: 
It also takes NEST Server URL from the query:
- `http://localhost:54286/#?nest_server_url=http://localhost:52425`
